### PR TITLE
Topic/display opts

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -11,6 +11,7 @@
 # error_bell=off                # sound terminal bell when command return code is not zero. (use setterm to set pitch and duration)
 # max_file_list_length=100      # in characters
 # count_only=off                # off - display file list; on - display file count
+# rawhex_len=6                  # length of git rawhex revision id display (use 0 to hide it)
 
 ############################################################   MODULES
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -56,6 +56,7 @@
         max_file_list_length=${max_file_list_length:-100}
         upcase_hostname=${upcase_hostname:-on}
         count_only=${count_only:-off}
+        rawhex_len=${rawhex_len:-6}
 
         aj_max=20
 
@@ -483,9 +484,13 @@ parse_git_status() {
 
 
         ####  GET GIT HEX-REVISION
-        rawhex=`git rev-parse HEAD 2>/dev/null`
-        rawhex=${rawhex/HEAD/}
-        rawhex=${rawhex:0:6}
+        if  [[ $rawhex_len -gt 0 ]] ;  then
+                rawhex=`git rev-parse HEAD 2>/dev/null`
+                rawhex=${rawhex/HEAD/}
+                rawhex="$white=${rawhex:0:$rawhex_len}"
+        else
+                rawhex=""
+        fi
 
         #### branch
         branch=${branch/master/M}
@@ -511,7 +516,7 @@ parse_git_status() {
                         fi
                         #branch="<$branch>"
                 fi
-                vcs_info="$branch$white=$rawhex"
+                vcs_info="$branch$rawhex"
 
         fi
  }


### PR DESCRIPTION
Hello,

I added two options to git-prompt. Feel free to include them in your project if you like them.
- count_only : instead of displaying untracked/added/changed filenames only display count of untracked/added/changed files
- rawhex_len: for git display rawhex_len characters of the revision id; using 0 as len hides the rawhex id 

Thanks for your great work,

 Thomas
