### PR TITLE
Fixes for git v1.7

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -450,6 +450,11 @@ parse_git_status() {
                             s/^#	unmerged:   '"$file_regex"'/	[[ \" ${modified_files[*]} \" =~ \" \1 \" ]] || modified_files[${#modified_files[@]}]=\"\1\"/p
                         }
 
+                        /^# Unmerged paths:/,/^[^#]/ {
+                            s/^# Unmerged paths:/modified=modified;/p
+                            s/^#	both modified:\s*'"$file_regex"'/	[[ \" ${modified_files[*]} \" =~ \" \1 \" ]] || modified_files[${#modified_files[@]}]=\"\1\"/p
+                        }
+
                         /^# Untracked files:/,/^[^#]/{
                             s/^# Untracked files:/untracked=untracked;/p
                             s/^#	'"$file_regex"'/		[[ \" ${untracked_files[*]} ${modified_files[*]} ${added_files[*]} \" =~ \" \1 \" ]] || untracked_files[${#untracked_files[@]}]=\"\1\"/p


### PR DESCRIPTION
Hi Leonid:

Modified files (either not yet committed, or in merge conflicts) were not displayed in the prompt for me with git v1.7 on Debian Wheezy.  I have fixed the problem by adding recognition of git status's output sections "Changes not staged for commit" and "Unmerged paths".  Please check and merge.  Thanks.

Best regards,
Tibor Simko
