### PR TITLE
Support for RVM, virtualenv, and a clock

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -19,6 +19,9 @@
 # svn_module=off
 # hg_module=on
 # vim_module=on
+# rvm_module=off
+# venv_module=off
+# clock_module=off
 
 
 ###########################################################   DEFAULT OBJECTS
@@ -44,6 +47,9 @@
 #  useful for directories for which it is difficult to maintain .gitignore so
 #  they are always dirty  (ex: home, /etc) or directory with huge repo (ex: linux src)
 ## vcs_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
+
+#  Format string for `date +` when using the clock module
+# clock_format=%H:%M:%S
 
 ###########################################################   COLOR 
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -25,8 +25,10 @@
         vim_module=${vim_module:-on}
         rvm_module=${rvm_module:-on}
         venv_module=${venv_module:-on}
+        clock_module=${clock_module:-off}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
+        clock_format=${clock_format:-%H:%M:%S}
 
 
         #### dir, rc, root color
@@ -57,6 +59,7 @@
              detached_vcs_color=${detached_vcs_color:-RED}
                       rvm_color=${rvm_color:-GREEN}
                      venv_color=${venv_color:-YELLOW}
+                    clock_color=${clock_color:-WHITE}
 
              if [[ $OSTYPE == "linux-gnu" ]] ;  then                # no linux OSs do not support extra colors
                   hex_vcs_color=${hex_vcs_color:-dim}
@@ -148,6 +151,7 @@
                   hex_vcs_color=${!hex_vcs_color}
                       rvm_color=${!rvm_color}
                      venv_color=${!venv_color}
+                    clock_color=${!clock_color}
 
         unset PROMPT_COMMAND
 
@@ -716,6 +720,7 @@ prompt_command_function() {
         parse_vcs_status
         [[ $rvm_module = "on" ]] && type rvm >&/dev/null && parse_rvm_status
         [[ $venv_module = "on" ]] && type virtualenv >&/dev/null && parse_venv_status
+        [[ $clock_module = "on" ]] && local clock="$clock_color$(date +$clock_format) "
 
 
 
@@ -728,7 +733,7 @@ prompt_command_function() {
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
 
-        PS1="$colors_reset$rc$head_local$venv_info$rvm_info$color_who_where$dir_color$cwd$tail_local$dir_color$prompt_char $colors_reset"
+        PS1="$colors_reset$clock$rc$head_local$venv_info$rvm_info$color_who_where$dir_color$cwd$tail_local$dir_color$prompt_char $colors_reset"
 
         unset head_local tail_local pwd
  }

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -23,8 +23,8 @@
         svn_module=${svn_module:-off}
         hg_module=${hg_module:-on}
         vim_module=${vim_module:-on}
-        rvm_module=${rvm_module:-on}
-        venv_module=${venv_module:-on}
+        rvm_module=${rvm_module:-off}
+        venv_module=${venv_module:-off}
         clock_module=${clock_module:-off}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -24,6 +24,7 @@
         hg_module=${hg_module:-on}
         vim_module=${vim_module:-on}
         rvm_module=${rvm_module:-on}
+        venv_module=${venv_module:-on}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
 
@@ -55,6 +56,7 @@
                    op_vcs_color=${op_vcs_color:-MAGENTA}
              detached_vcs_color=${detached_vcs_color:-RED}
                       rvm_color=${rvm_color:-GREEN}
+                     venv_color=${venv_color:-YELLOW}
 
              if [[ $OSTYPE == "linux-gnu" ]] ;  then                # no linux OSs do not support extra colors
                   hex_vcs_color=${hex_vcs_color:-dim}
@@ -145,6 +147,7 @@
              detached_vcs_color=${!detached_vcs_color}
                   hex_vcs_color=${!hex_vcs_color}
                       rvm_color=${!rvm_color}
+                     venv_color=${!venv_color}
 
         unset PROMPT_COMMAND
 
@@ -646,6 +649,23 @@ parse_rvm_status() {
         [[ "$rvm_info" ]] && rvm_info="$rvm_color[$rvm_info] "
 }
 
+parse_venv_status() {
+        if [[ "$VIRTUAL_ENV" ]]; then
+                local env="$VIRTUAL_ENV"
+                local env_name=""
+                while [[ "$env" && "$env" != "/" ]]; do
+                        env_name="$(basename $env)"
+                        if [[ "${env_name:0:1}" != "." ]]; then
+                                venv_info="$venv_color[$env_name] "
+                                return 0
+                        fi
+                        env="$(dirname $env)"
+                done
+        fi
+        venv_info=""
+        return 1
+}
+
 disable_set_shell_label() {
         trap - DEBUG  >& /dev/null
  }
@@ -695,6 +715,8 @@ prompt_command_function() {
 
         parse_vcs_status
         [[ $rvm_module = "on" ]] && type rvm >&/dev/null && parse_rvm_status
+        [[ $venv_module = "on" ]] && type virtualenv >&/dev/null && parse_venv_status
+
 
 
         # autojump
@@ -706,7 +728,7 @@ prompt_command_function() {
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
 
-        PS1="$colors_reset$rc$head_local$rvm_color$rvm_info$color_who_where$dir_color$cwd$tail_local$dir_color$prompt_char $colors_reset"
+        PS1="$colors_reset$rc$head_local$venv_info$rvm_info$color_who_where$dir_color$cwd$tail_local$dir_color$prompt_char $colors_reset"
 
         unset head_local tail_local pwd
  }

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -23,6 +23,7 @@
         svn_module=${svn_module:-off}
         hg_module=${hg_module:-on}
         vim_module=${vim_module:-on}
+        rvm_module=${rvm_module:-on}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
 
@@ -53,6 +54,7 @@
             untracked_vcs_color=${untracked_vcs_color:-BLUE}    # Untracked files:
                    op_vcs_color=${op_vcs_color:-MAGENTA}
              detached_vcs_color=${detached_vcs_color:-RED}
+             rvm_color=${rvm_color:-GREEN}
 
              if [[ $OSTYPE == "linux-gnu" ]] ;  then                # no linux OSs do not support extra colors
                   hex_vcs_color=${hex_vcs_color:-dim}
@@ -142,6 +144,7 @@
              addmoded_vcs_color=${!addmoded_vcs_color}
              detached_vcs_color=${!detached_vcs_color}
                   hex_vcs_color=${!hex_vcs_color}
+                      rvm_color=${!rvm_color}
 
         unset PROMPT_COMMAND
 
@@ -634,6 +637,15 @@ parse_vcs_status() {
         #tail_local="${tail_local+$vcs_color $tail_local}${dir_color}"
  }
 
+parse_rvm_status() {
+        local gemset=$(echo $GEM_HOME | awk -F'@' '{print $2}')
+        [ "$gemset" != "" ] && gemset="@$gemset"
+        local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $2}')
+        [ "$version" == "$default_rvm_version" ] && version=""
+        rvm_info="$version$gemset"
+        [[ "$rvm_info" ]] && rvm_info="[$rvm_info] "
+}
+
 disable_set_shell_label() {
         trap - DEBUG  >& /dev/null
  }
@@ -682,6 +694,8 @@ prompt_command_function() {
         set_shell_label "${cwd##[/~]*/}/"       # default label - path last dir
 
         parse_vcs_status
+        [[ $rvm_module = "on" ]] && type rvm >&/dev/null && parse_rvm_status
+
 
         # autojump
         if [[ ${aj_dir_list[aj_idx%aj_max]} != $PWD ]] ; then
@@ -692,7 +706,7 @@ prompt_command_function() {
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
 
-        PS1="$colors_reset$rc$head_local$color_who_where$dir_color$cwd$tail_local$dir_color$prompt_char $colors_reset"
+        PS1="$colors_reset$rc$head_local$rvm_color$rvm_info$color_who_where$dir_color$cwd$tail_local$dir_color$prompt_char $colors_reset"
 
         unset head_local tail_local pwd
  }

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -643,7 +643,7 @@ parse_rvm_status() {
         local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $2}')
         [ "$version" == "$default_rvm_version" ] && version=""
         rvm_info="$version$gemset"
-        [[ "$rvm_info" ]] && rvm_info="[$rvm_info] "
+        [[ "$rvm_info" ]] && rvm_info="$rvm_color[$rvm_info] "
 }
 
 disable_set_shell_label() {

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -54,7 +54,7 @@
             untracked_vcs_color=${untracked_vcs_color:-BLUE}    # Untracked files:
                    op_vcs_color=${op_vcs_color:-MAGENTA}
              detached_vcs_color=${detached_vcs_color:-RED}
-             rvm_color=${rvm_color:-GREEN}
+                      rvm_color=${rvm_color:-GREEN}
 
              if [[ $OSTYPE == "linux-gnu" ]] ;  then                # no linux OSs do not support extra colors
                   hex_vcs_color=${hex_vcs_color:-dim}


### PR DESCRIPTION
This adds support for display the active RVM version/gemset, active virtualenv, and showing the current time. The clock module is off by default since it does involve a subcommand, the other two are just reading existing environment variables. Each of the three features is well divided in the commits, so you can also just cherrypick a subset of them if you want.
