### PR TITLE
configurable screen marker

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -12,6 +12,7 @@
 # max_file_list_length=100      # in characters
 # count_only=off                # off - display file list; on - display file count
 # rawhex_len=5                  # length of git rawhex revision id display (use 0 to hide it)
+# screen_marker=sCRn            # marker for GNU screen
 
 ############################################################   MODULES
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -65,6 +65,9 @@
 
         aj_max=20
 
+        ### GNU screen marker
+        screen_marker=${screen_marker:-sCRn}
+        screen_marker="$screen_marker " # add trailing blank
 
 #####################################################################  post config
 
@@ -150,7 +153,6 @@
         fi
 
         ####################################################################  MARKERS
-        screen_marker="sCRn"
         if [[ $LC_CTYPE =~ "UTF" && $TERM != "linux" ]];  then
                 elipses_marker="…"
         else
@@ -229,7 +231,7 @@ set_shell_label() {
 
         screen_label() {
                 # FIXME: run this only if screen is in xterm (how to test for this?)
-                xterm_label  "$screen_marker  $plain_who_where $@"
+                xterm_label  "$screen_marker$plain_who_where$@"
 
                 # FIXME $STY not inherited though "su -"
                 [ "$STY" ] && screen -S $STY -X title "$*"
@@ -246,7 +248,7 @@ set_shell_label() {
                         xterm* | rxvt* | gnome-terminal | konsole | eterm | wterm )
                                 # is there a capability which we can to test
                                 # for "set term title-bar" and its escapes?
-                                xterm_label  "$plain_who_where $@"
+                                xterm_label  "$plain_who_where$@"
                                 ;;
 
                         *)


### PR DESCRIPTION
Makes GNU screen marker configurable (instead of hard coded sCRn)
and removes extra white spaces when constructing screen label.
This is useful for cleaner screen window titles.
