### PR TITLE
Handle more special chars in branch names when checking Git freshness

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -428,9 +428,9 @@ parse_git_status() {
                         s/^nothing to commi.*/clean=clean/p
                         s/^# Initial commi.*/init=init/p
 
-                        s/^# Your branch is ahead of .[/[:alnum:]]\+. by [[:digit:]]\+ commit.*/freshness=${WHITE}↑/p
-                        s/^# Your branch is behind .[/[:alnum:]]\+. by [[:digit:]]\+ commit.*/freshness=${YELLOW}↓/p
-                        s/^# Your branch and .[/[:alnum:]]\+. have diverged.*/freshness=${YELLOW}↕/p
+                        s/^# Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}↑/p
+                        s/^# Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}↓/p
+                        s/^# Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}↕/p
 
                         /^# Changes to be committed:/,/^# [A-Z]/ {
                             s/^# Changes to be committed:/added=added;/p


### PR DESCRIPTION
Hi,

I sometimes use ‘`_`’ characters in my branch names, so the “`freshness=${YELLOW}↓`” code was not working for those branches. You can look at `git help git-check-ref-format` to learn all about valid ref names, but in my patch I only made it so the quotes match.

Thanks,
Amir
