### PR TITLE
Fixed Mercurial repository detection

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -375,8 +375,7 @@ parse_svn_status() {
 parse_hg_status() {
 
         # ☿
-
-        [[  -d ./.hg/ ]]  ||  return  1
+        hg_root=`hg root 2>/dev/null` || return 1
 
         vcs=hg
 


### PR DESCRIPTION
Currently, the prompt only triggers when you're at the root of a Mercurial directory.

This patch allows the prompt to also trigger in subdirectories of the repo.
