### PR TITLE
Show current bookmark in Mercurial

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -393,8 +393,13 @@ parse_hg_status() {
 
         branch=`hg branch 2> /dev/null`
 
+        [[ -f $hg_root/.hg/bookmarks.current ]] && bookmark=`cat "$hg_root/.hg/bookmarks.current"`
+
         [[ -z $modified ]]   &&   [[ -z $untracked ]]   &&   [[ -z $added ]]   &&   clean=clean
         vcs_info=${branch/default/D}
+        if [[ "$bookmark" ]] ;  then
+                vcs_info+=/$bookmark
+        fi
  }
 
 


### PR DESCRIPTION
This patch adds the current bookmark information to the prompt for Mercurial repositories.

(Bookmarks in hg are similar to the lightweight branches in git, and have been a core feature of Mercurial since version 1.8.)
