### PR TITLE
Prevent "detached" message from appearing in the prompt when $git_dir includes space character(s)

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -465,7 +465,7 @@ parse_git_status() {
                     '
         )"
 
-        if  ! grep -q "^ref:" $git_dir/HEAD  2>/dev/null;   then
+        if  ! grep -q "^ref:" "$git_dir/HEAD"  2>/dev/null;   then
                 detached=detached
         fi
 


### PR DESCRIPTION
For example, assume a git repository located at /Volumes/Macintosh HD/Users/tom/src/myrepository:
- this bug does not appear when the working directory is the root of the git repository ( e.g. /Volumes/Macintosh HD/Users/tom/src/myrepository ), as $git_dir returns ".git"
- the bug only appears if the directory is changed to one other than the root of the repository ( e.g. /Volumes/Macintosh HD/Users/tom/src/myrepository/DIRECTORY ), as $git_dir will then return the full path "/Volumes/Macintosh HD/Users/tom/src/myrepository/.git".  The space between "Macintosh" and "HD" will cause 'grep "^ref:" $git_dir/HEAD' to fail.  Adding quotation marks around $git_dir/HEAD allows the grep test to succeed, even when the path includes space character(s).
