### PR TITLE
color_who_where: add extra \ escape if $id has \

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -329,7 +329,7 @@ set_shell_label() {
 
         if [[ -n $id  || -n $host ]] ;   then
                 [[ -n $id  &&  -n $host ]]  &&  at='@'  || at=''
-                color_who_where="${id}${host:+$host_color$at$host}${tty:+ $tty}"
+                color_who_where="${id//\\/\\\\}${host:+$host_color$at$host}${tty:+ $tty}"
                 plain_who_where="${id}$at$host"
 
                 # add trailing " "


### PR DESCRIPTION
likewise-open user id's contain a backslash:
domain\user

The backslash needs to be escaped when colorized

Signed-off-by: Jon Ringle jringle@gridpoint.com
