### PR TITLE
Jringle/file list

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -5,7 +5,12 @@
 ###    lines commented-out with double '##' are examples
 ###
 ###    NOTE: this is bash syntax - no spaces around "="
-
+###
+###    You can override on a git per-repo by creating a .git/.git-prompt.conf
+###    NOTE: If you do this, prefix any variable overrides with 'local'
+###    i.e.:
+###        local file_list_mode=fileonly
+###
 ###########################################################
 
 # error_bell=off                # sound terminal bell when command return code is not zero. (use setterm to set pitch and duration)

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -432,6 +432,11 @@ parse_git_status() {
 
         [[  -n ${git_dir/./} ]]   ||   return  1
 
+        # Allow per-repo configuration overrides
+        conf=${git_dir}/.git-prompt.conf;
+        [[ -r $conf ]]  && . $conf
+        unset conf
+
         vcs=git
 
         ##########################################################   GIT STATUS


### PR DESCRIPTION
Provide several modes for displaying list of added/mod/untrack files

```
file_list_mode=fileonly
Displays just the filename only regardless of which directory a changed
file is at.

file_list_mode=fullpath
Displays the path and filename of changed files

file_list_mode=topdir
Display just the top level directories if there are changes in that
directory or any sub-directory and filenames if they are in the base
directory of the repo.
This is the behavior that exists before this commit

file_list_mode=fulldir
Display the full directory name for directories where there are changes
and filenames if they are in the base directory of the repo.
IMHO, this is a more useful mode.
```
