### PR TITLE
Add support for tmux "tty" display

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -20,6 +20,7 @@
 # hg_module=on
 # vim_module=on
 # virtualenv_module=on
+# tmux_module=off
 
 
 ###########################################################   DEFAULT OBJECTS
@@ -45,6 +46,9 @@
 #  useful for directories for which it is difficult to maintain .gitignore so
 #  they are always dirty  (ex: home, /etc) or directory with huge repo (ex: linux src)
 ## vcs_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
+
+# Format for tmux "tty"
+# tmux_tty_string="#Ip#P"
 
 ###########################################################   COLOR 
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -34,6 +34,8 @@
         hg_module=${hg_module:-on}
         vim_module=${vim_module:-on}
         virtualenv_module=${virtualenv_module:-on}
+        tmux_module=${tmux_module:-off}
+        tmux_tty_string=${tmux_tty_string:-"#Ip#P"}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
 
@@ -279,6 +281,8 @@ set_shell_label() {
                 #               # tty="${WINDOW:+s}$WINDOW${WINDOW:+-}$tty"
                 #       tty="${WINDOW:+s}$WINDOW"  # replace tty name with screen number
                 tty="$WINDOW"  # replace tty name with screen number
+        elif [[ $tmux_module == "on" && $TMUX_PANE ]]; then
+                tty=`tmux display -t $TMUX_PANE -p "$tmux_tty_string"`
         fi
 
         # we don't need tty name under X11


### PR DESCRIPTION
- Allow users to define a tmux string to be shown as the tty
- Sets default string to "#Ip#P"
- Module defaults to off (on causes a small delay in loading due to
  shelling out to tmux)
