### PR TITLE
Added new modules for battery status, makefile, foreground jobs, made modules reorderable, plus other fixes and upgrades

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -20,6 +20,7 @@
 # hg_module=on
 # vim_module=on
 # virtualenv_module=on
+# battery_module=off
 
 
 ###########################################################   DEFAULT OBJECTS

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -80,10 +80,12 @@
 # hg_multiple_heads_display=on
 
 ### Display elapsed time used by long-running command if it's above this threshold:
+### (seconds)
 # command_time_threshold=15
 
 ### Colors and color change thresholds for load display.
 ### If the load is under the first value in the list, the display is supressed.
+### Both have to be arrays with the same number of elements
 # load_colors=(BLACK red RED whiteonred)
 # load_thresholds=(100 200 300 400)
 

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -12,6 +12,7 @@
 # max_file_list_length=100      # in characters
 # count_only=off                # off - display file list; on - display file count
 # rawhex_len=5                  # length of git rawhex revision id display (use 0 to hide it)
+# enable_utf8=on                # use utf8 characters in prompt
 
 ############################################################   MODULES
 

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -26,7 +26,16 @@
 
 
 ###########################################################   DEFAULT OBJECTS
-###  Default objects are not displayed.  Example:
+###  Default user and hostname can be abbreviated or suppressed.
+###  Valid settings:
+###   * keep   - display fully
+###   * abbrev - abbreviate to first character
+###   * delete - do not display at all
+
+# default_host_abbrev_mode=delete
+# default_id_abbrev_mode=delete
+
+###  Examples:
 
 ## default_user=lvv             
 ## default_host="ahp"                   # remote host is always shown

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -120,8 +120,8 @@
 #               clean_vcs_color=blue      # nothing to commit (working directory clean)
 #            modified_vcs_color=red       # Changed but not updated:
 #               added_vcs_color=green     # Changes to be committed:
-#               mixed_vcs_color=yellow    # 
 #           untracked_vcs_color=BLUE      # Untracked files:
+#             deleted_vcs_color=yellow    # Deleted files:
 #                  op_vcs_color=MAGENTA
 #            detached_vcs_color=RED
 #                 hex_vcs_color=BLACK	  # git revision id:  bright black (makes gray)

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -23,6 +23,7 @@
 # battery_module=off
 # make_module=off
 # jobs_module=on
+# rc_module=on
 
 
 ###########################################################   DEFAULT OBJECTS

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -59,6 +59,10 @@
 #  they are always dirty  (ex: home, /etc) or directory with huge repo (ex: linux src)
 ## vcs_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
 
+#  Do not check make status for listed directories
+#  useful for large projects where make -q would take several seconds
+## make_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -24,9 +24,10 @@
 # make_module=off
 # jobs_module=on
 # rc_module=on
+# command_time_module=on
 
 ### Order of modules
-# prompt_modules_order="RC VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE PROMPT"
+# prompt_modules_order="RC CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE PROMPT"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.
@@ -74,6 +75,9 @@
 
 ### Check for and display multiple hg heads
 # hg_multiple_heads_display=on
+
+### Display elapsed time used by long-running command if it's above this threshold:
+# command_time_threshold=15
 
 ###########################################################   COLOR 
 

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -21,6 +21,7 @@
 # vim_module=on
 # virtualenv_module=on
 # battery_module=off
+# make_module=off
 
 
 ###########################################################   DEFAULT OBJECTS
@@ -58,6 +59,8 @@
         #       virtualenv_color=green
         #       user_id_color=blue
         #       root_id_color=magenta
+        #       make_color_ok=BLACK
+        #       make_color_dirty=RED
 # else                                          #  B/W terminal
         #       dir_color=bw_bold
         #       rc_color=bw_bold

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -28,10 +28,11 @@
 # command_time_module=on
 # clock_module=off
 # load_module=on
+# sudo_module=off
 
 
 ### Order of modules
-# prompt_modules_order="RC LOAD CLOCK CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE"
+# prompt_modules_order="RC LOAD CLOCK CTIME VIRTUALENV VCS SUDO WHO_WHERE JOBS BATTERY CWD MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -81,6 +81,18 @@
 ### Display elapsed time used by long-running command if it's above this threshold:
 # command_time_threshold=15
 
+### Colors and color change thresholds for load display.
+### If the load is under the first value in the list, the display is supressed.
+# load_colors=(BLACK red RED whiteonred)
+# load_thresholds=(100 200 300 400)
+
+### Display style for load
+### valid options:
+###  * markonly         # only display the mark, supress the value
+###  * numeric          # display mark and numeric value
+###  * bar              # display mark and unicode bar chart
+# load_display_style=bar
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -72,6 +72,9 @@
 ###  * none - do not display at all
 # hg_revision_display=none
 
+### Check for and display multiple hg heads
+# hg_multiple_heads_display=on
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -65,6 +65,7 @@
         #       make_color_dirty=RED
         #       jobs_color_bkg=yellow
         #       jobs_color_stop=red
+        #       at_color=green
 # else                                          #  B/W terminal
         #       dir_color=bw_bold
         #       rc_color=bw_bold

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -25,9 +25,11 @@
 # jobs_module=on
 # rc_module=on
 # command_time_module=on
+# load_module=on
+
 
 ### Order of modules
-# prompt_modules_order="RC CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE PROMPT"
+# prompt_modules_order="RC LOAD CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE PROMPT"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -126,6 +126,7 @@
 #               added_vcs_color=green     # Changes to be committed:
 #           untracked_vcs_color=BLUE      # Untracked files:
 #             deleted_vcs_color=yellow    # Deleted files:
+#          conflicted_vcs_color=CYAN      # Conflicted files:
 #                  op_vcs_color=MAGENTA
 #            detached_vcs_color=RED
 #                 hex_vcs_color=BLACK	  # git revision id:  bright black (makes gray)

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -83,6 +83,7 @@
 #        if [[ -n "$cols" && $cols -ge 8 ]];  then                              #  if terminal supports colors
         #       dir_color=CYAN
         #       slash_color=BLUE
+        #       slash_color_readonly=MAGENTA
         #       prompt_color=white
         #       rc_color=red
         #       virtualenv_color=green

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -65,6 +65,13 @@
 #  useful for large projects where make -q would take several seconds
 ## make_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
 
+### Display revision number for Mercurial repositories
+### valid options:
+###  * num  - display local revision number
+###  * id   - display global revision id (hex string, truncated to rawhex_len characters
+###  * none - do not display at all
+# hg_revision_display=none
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -90,6 +90,7 @@
         #       jobs_color_bkg=yellow
         #       jobs_color_stop=red
         #       at_color=green
+        #       at_color_remote=RED
 # else                                          #  B/W terminal
         #       dir_color=bw_bold
         #       rc_color=bw_bold

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -29,7 +29,7 @@
 
 
 ### Order of modules
-# prompt_modules_order="RC LOAD CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE PROMPT"
+# prompt_modules_order="RC LOAD CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -25,6 +25,8 @@
 # jobs_module=on
 # rc_module=on
 
+### Order of modules
+# prompt_modules_order="RC VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE PROMPT"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -22,6 +22,7 @@
 # virtualenv_module=on
 # battery_module=off
 # make_module=off
+# jobs_module=on
 
 
 ###########################################################   DEFAULT OBJECTS
@@ -61,6 +62,8 @@
         #       root_id_color=magenta
         #       make_color_ok=BLACK
         #       make_color_dirty=RED
+        #       jobs_color_bkg=yellow
+        #       jobs_color_stop=red
 # else                                          #  B/W terminal
         #       dir_color=bw_bold
         #       rc_color=bw_bold

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -57,6 +57,7 @@
 #        if [[ -n "$cols" && $cols -ge 8 ]];  then                              #  if terminal supports colors
         #       dir_color=CYAN
         #       slash_color=BLUE
+        #       prompt_color=white
         #       rc_color=red
         #       virtualenv_color=green
         #       user_id_color=blue

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -25,11 +25,12 @@
 # jobs_module=on
 # rc_module=on
 # command_time_module=on
+# clock_module=off
 # load_module=on
 
 
 ### Order of modules
-# prompt_modules_order="RC LOAD CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE"
+# prompt_modules_order="RC LOAD CLOCK CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.
@@ -93,6 +94,15 @@
 ###  * bar              # display mark and unicode bar chart
 # load_display_style=bar
 
+
+### Clock options
+### Display style - analog or digital
+# clock_style=analog
+
+### Alert interval, in minutes
+### if 0, clock is always shown, otherwise it's displayed only every x minutes
+# clock_alert_interval=30
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 
@@ -113,6 +123,7 @@
         #       jobs_color_stop=red
         #       at_color=green
         #       at_color_remote=RED
+        #       clock_color=BLACK
 # else                                          #  B/W terminal
         #       dir_color=bw_bold
         #       rc_color=bw_bold

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -56,6 +56,7 @@
 #        cols=`tput colors`
 #        if [[ -n "$cols" && $cols -ge 8 ]];  then                              #  if terminal supports colors
         #       dir_color=CYAN
+        #       slash_color=BLUE
         #       rc_color=red
         #       virtualenv_color=green
         #       user_id_color=blue

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -80,10 +80,12 @@ hg_revision_display=num
 # hg_multiple_heads_display=on
 
 ### Display elapsed time used by long-running command if it's above this threshold:
+### (seconds)
 # command_time_threshold=15
 
 ### Colors and color change thresholds for load display.
 ### If the load is under the first value in the list, the display is supressed.
+### Both have to be arrays with the same number of elements
 # load_colors=(BLACK red RED whiteonred)
 # load_thresholds=(100 200 300 400)
 

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -81,6 +81,18 @@ hg_revision_display=num
 ### Display elapsed time used by long-running command if it's above this threshold:
 # command_time_threshold=15
 
+### Colors and color change thresholds for load display.
+### If the load is under the first value in the list, the display is supressed.
+# load_colors=(BLACK red RED whiteonred)
+# load_thresholds=(100 200 300 400)
+
+### Display style for load
+### valid options:
+###  * markonly         # only display the mark, supress the value
+###  * numeric          # display mark and numeric value
+###  * bar              # display mark and unicode bar chart
+# load_display_style=bar
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -28,10 +28,11 @@ rc_module=on
 command_time_module=on
 load_module=on
 clock_module=on
+sudo_module=on
 
 
 ### order of modules
-prompt_modules_order="RC LOAD CLOCK CTIME VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
+prompt_modules_order="RC LOAD CLOCK CTIME VIRTUALENV SUDO WHO_WHERE JOBS BATTERY CWD VCS MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.
@@ -126,6 +127,7 @@ clock_alert_interval=30
                at_color=green
                at_color_remote=RED
                clock_color=WHITE
+               sudo_color=RED
 
 # else                                          #  B/W terminal
         #       dir_color=bw_bold

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -16,7 +16,7 @@ count_only=on                   # off - display file list; on - display file cou
 ############################################################   MODULES
 
 # git_module=on
-# svn_module=off
+svn_module=on
 # hg_module=on
 vim_module=off
 virtualenv_module=off
@@ -122,8 +122,8 @@ hg_revision_display=num
 #               clean_vcs_color=blue      # nothing to commit (working directory clean)
 #            modified_vcs_color=red       # Changed but not updated:
 #               added_vcs_color=green     # Changes to be committed:
-#               mixed_vcs_color=yellow    # 
 #           untracked_vcs_color=BLUE      # Untracked files:
+#             deleted_vcs_color=yellow    # Deleted files:
 #                  op_vcs_color=MAGENTA
 #            detached_vcs_color=RED
 #                 hex_vcs_color=white	  # git revision id:  bright black (makes gray)

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -72,6 +72,9 @@ make_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
 ###  * none - do not display at all
 hg_revision_display=num
 
+### Check for and display multiple hg heads
+# hg_multiple_heads_display=on
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -83,6 +83,7 @@ hg_revision_display=num
 #        if [[ -n "$cols" && $cols -ge 8 ]];  then                              #  if terminal supports colors
                dir_color=BLUE
                slash_color=CYAN
+               slash_color_readonly=MAGENTA
                prompt_color=colors_reset
                rc_color=red
                virtualenv_color=green

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -90,6 +90,7 @@ hg_revision_display=num
                jobs_color_bkg=yellow
                jobs_color_stop=red
                at_color=green
+               at_color_remote=RED
 
 # else                                          #  B/W terminal
         #       dir_color=bw_bold

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -52,7 +52,7 @@ cwd_cmd='cwd_truncate $(($COLUMNS/4))'    # display only last N chars of path
 ###########################################################   ETC
 
 #  Some don't like hostname in uppercase
-#  upcase_hostname=on # =off
+upcase_hostname=off # =off
 #  Some don't like long hostname
 #  short_hostname=off # =on
 

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -128,6 +128,7 @@ hg_revision_display=num
 #               added_vcs_color=green     # Changes to be committed:
 #           untracked_vcs_color=BLUE      # Untracked files:
 #             deleted_vcs_color=yellow    # Deleted files:
+#          conflicted_vcs_color=CYAN      # Conflicted files:
 #                  op_vcs_color=MAGENTA
 #            detached_vcs_color=RED
 #                 hex_vcs_color=white	  # git revision id:  bright black (makes gray)

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -24,9 +24,10 @@ battery_module=on
 make_module=on
 # jobs_module=on
 rc_module=on
+command_time_module=on
 
 ### order of modules
-prompt_modules_order="RC VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
+prompt_modules_order="RC CTIME VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.
@@ -74,6 +75,9 @@ hg_revision_display=num
 
 ### Check for and display multiple hg heads
 # hg_multiple_heads_display=on
+
+### Display elapsed time used by long-running command if it's above this threshold:
+# command_time_threshold=15
 
 ###########################################################   COLOR 
 

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -26,10 +26,11 @@ make_module=on
 rc_module=on
 command_time_module=on
 load_module=on
+clock_module=on
 
 
 ### order of modules
-prompt_modules_order="RC LOAD CTIME VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
+prompt_modules_order="RC LOAD CLOCK CTIME VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.
@@ -93,6 +94,14 @@ hg_revision_display=num
 ###  * bar              # display mark and unicode bar chart
 # load_display_style=bar
 
+### Clock options
+### Display style - analog or digital
+clock_style=analog
+
+### Alert interval, in minutes
+### if 0, clock is always shown, otherwise it's displayed only every x minutes
+clock_alert_interval=30
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 
@@ -113,6 +122,7 @@ hg_revision_display=num
                jobs_color_stop=red
                at_color=green
                at_color_remote=RED
+               clock_color=WHITE
 
 # else                                          #  B/W terminal
         #       dir_color=bw_bold

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -12,6 +12,7 @@
 max_file_list_length=30         # in characters
 count_only=on                   # off - display file list; on - display file count
 # rawhex_len=5                  # length of git rawhex revision id display (use 0 to hide it)
+# enable_utf8=on                # use utf8 characters in prompt
 
 ############################################################   MODULES
 

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -1,0 +1,131 @@
+
+###  GIT-PROMPT.SH CONFIG
+###
+###    lines commented-out with single '#' are default values
+###    lines commented-out with double '##' are examples
+###
+###    NOTE: this is bash syntax - no spaces around "="
+
+###########################################################
+
+# error_bell=off                # sound terminal bell when command return code is not zero. (use setterm to set pitch and duration)
+max_file_list_length=30         # in characters
+count_only=on                   # off - display file list; on - display file count
+# rawhex_len=5                  # length of git rawhex revision id display (use 0 to hide it)
+
+############################################################   MODULES
+
+# git_module=on
+# svn_module=off
+# hg_module=on
+vim_module=off
+virtualenv_module=off
+battery_module=on
+make_module=on
+# jobs_module=on
+rc_module=on
+
+### order of modules
+prompt_modules_order="RC VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE PROMPT"
+
+###########################################################   DEFAULT OBJECTS
+###  Default user and hostname can be abbreviated or suppressed.
+###  Valid settings:
+###   * keep   - display fully
+###   * abbrev - abbreviate to first character
+###   * delete - do not display at all
+
+default_host_abbrev_mode=abbrev
+default_id_abbrev_mode=abbrev
+
+###  Examples:
+
+default_user=kikuchiyo
+default_host=aryabhata                   # remote host is always shown
+## default_domain="lvvnet"      
+
+###########################################################   Current Working Dir display
+#  cwd_cmd='\w'                 # display full path
+## cwd_cmd='\W'                 # display only last dir of path
+cwd_cmd='cwd_truncate $(($COLUMNS/4))'    # display only last N chars of path
+
+###########################################################   ETC
+
+#  Some don't like hostname in uppercase
+#  upcase_hostname=on # =off
+#  Some don't like long hostname
+#  short_hostname=off # =on
+
+#  Do not do VCS parsing for listed directories
+#  useful for directories for which it is difficult to maintain .gitignore so
+#  they are always dirty  (ex: home, /etc) or directory with huge repo (ex: linux src)
+## vcs_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
+
+#  Do not check make status for listed directories
+#  useful for large projects where make -q would take several seconds
+make_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
+
+### Display revision number for Mercurial repositories
+### valid options:
+###  * num  - display local revision number
+###  * id   - display global revision id (hex string, truncated to rawhex_len characters
+###  * none - do not display at all
+hg_revision_display=num
+
+###########################################################   COLOR 
+
+###  directory, exit code, root color 
+
+#        cols=`tput colors`
+#        if [[ -n "$cols" && $cols -ge 8 ]];  then                              #  if terminal supports colors
+               dir_color=BLUE
+               slash_color=CYAN
+               prompt_color=colors_reset
+               rc_color=red
+               virtualenv_color=green
+               user_id_color=GREEN
+               root_id_color=magenta
+               make_color_ok=BLACK
+               make_color_dirty=RED
+               jobs_color_bkg=yellow
+               jobs_color_stop=red
+               at_color=green
+
+# else                                          #  B/W terminal
+        #       dir_color=bw_bold
+        #       rc_color=bw_bold
+# fi
+
+### prompt character for root/non-root, default '>' for both
+#	prompt_char='>'
+#	root_prompt_char='>'
+	prompt_char='$'
+##	prompt_char='➔'
+	root_prompt_char='#'
+
+#####  Per host color
+
+### Per host color.  If not set, color will be derived from hostname checksum).
+### Variable name is uppercase-short-hostname with appended "_host_color"
+### Example per-host-color config:  
+
+##          TASHA_host_color=cyan
+##             AL_host_color=green
+##            AHP_host_color=white
+        ARYABHATA_host_color=green
+        PALATABLA_host_color=cyan
+
+#####  VCS (version control system)  state colors
+
+#                init_vcs_color=WHITE     # initial
+#               clean_vcs_color=blue      # nothing to commit (working directory clean)
+#            modified_vcs_color=red       # Changed but not updated:
+#               added_vcs_color=green     # Changes to be committed:
+#               mixed_vcs_color=yellow    # 
+#           untracked_vcs_color=BLUE      # Untracked files:
+#                  op_vcs_color=MAGENTA
+#            detached_vcs_color=RED
+#                 hex_vcs_color=white	  # git revision id:  bright black (makes gray)
+
+
+# :vim:ft=sh ts=8 sw=8 et:

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -25,9 +25,11 @@ make_module=on
 # jobs_module=on
 rc_module=on
 command_time_module=on
+load_module=on
+
 
 ### order of modules
-prompt_modules_order="RC CTIME VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
+prompt_modules_order="RC LOAD CTIME VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.

--- a/git-prompt.conf.mine
+++ b/git-prompt.conf.mine
@@ -26,7 +26,7 @@ make_module=on
 rc_module=on
 
 ### order of modules
-prompt_modules_order="RC VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE PROMPT"
+prompt_modules_order="RC VIRTUALENV WHO_WHERE JOBS BATTERY CWD VCS MAKE"
 
 ###########################################################   DEFAULT OBJECTS
 ###  Default user and hostname can be abbreviated or suppressed.

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -782,12 +782,18 @@ parse_git_status() {
         eval " $(
                 LANG=C git status --porcelain 2>/dev/null |
                         sed -n '
-                                s,^[MARC]. \([^\"][^/]*/\?\).*,         added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
-                                s,^[MARC]. \"\([^/]\+/\?\).*\"$,        added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
-                                s,^.[MAU] \([^\"][^/]*/\?\).*,          modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
-                                s,^.[MAU] \"\([^/]\+/\?\).*\"$,         modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
-                                s,^?? \([^\"][^/]*/\?\).*,              untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
-                                s,^?? \"\([^/]\+/\?\).*\"$,             untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
+                                s,^U. \([^\"][^/]*/\?\).*,         conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
+                                s,^U. \"\([^/]\+/\?\).*\"$,        conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
+                                s,^.U \([^\"][^/]*/\?\).*,         conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
+                                s,^.U \"\([^/]\+/\?\).*\"$,        conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
+                                s,^D. \([^\"][^/]*/\?\).*,         deleted=deleted;       [[ \" ${deleted_files[@]} \"    =~ \" \1 \" ]]   || deleted_files[${#conflicted_files[@]}]=\"\1\",p
+                                s,^D. \"\([^/]\+/\?\).*\"$,        deleted=deleted;       [[ \" ${deleted_files[@]} \"    =~ \" \1 \" ]]   || deleted_files[${#conflicted_files[@]}]=\"\1\",p
+                                s,^[MARC]. \([^\"][^/]*/\?\).*,    added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
+                                s,^[MARC]. \"\([^/]\+/\?\).*\"$,   added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
+                                s,^.[MA] \([^\"][^/]*/\?\).*,      modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
+                                s,^.[MA] \"\([^/]\+/\?\).*\"$,     modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
+                                s,^?? \([^\"][^/]*/\?\).*,         untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
+                                s,^?? \"\([^/]\+/\?\).*\"$,        untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
                         '   # |tee /dev/tty
         )"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -831,7 +831,7 @@ parse_hg_status() {
         # if we're not in a hg directory, this takes exactly the same time as 'hg root' would do,
         # and if we're in a hg dir, we don't have to call 'hg branch' and 'hg id' separately.
         local id_str
-        id_str=$(hg log --follow -l 1 --template '{rev}\x1f{node}\x1f{tags}\x1f{branch}\x1f{bookmarks}' 2> /dev/null) || return 1
+        id_str=$(hg log --follow -l 1 --template '{rev}\x1f{node}\x1f{tags}\x1f{branches}\x1f{bookmarks}' 2> /dev/null) || return 1
 
         # This contrived way is necessary because branch names and tags can contain spaces.
         # The ASCII "Unit separator" \x1f was chosen as a "safe" separator character

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -611,7 +611,7 @@ create_load_indicator () {
 
         load_str=$(uptime | sed -ne 's/.* load average: \([0-9]\.[0-9]\{1,2\}\).*/\1/p')
         load_value=${load_str/\./}
-        load_value=${load_value##0*}
+        load_value=$((10#$load_value))
 
         if [[ $load_value -lt ${load_thresholds[0]} ]]; then 
             load_indicator=""

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -438,6 +438,11 @@ create_battery_indicator () {
         # if laptop on AC, charging: ▕⚡▏
         # if laptop on battery: one of ▕▁▏▕▂▏▕▃▏▕▄▏▕▅▏▕▆▏▕▇▏▕█▏
         # color: red if power < 30 %, else normal
+
+        local battery_string
+        local battery_percent
+        local battery_color
+        local tmp
         battery_string=$(acpi -b)
 
         if [[ $battery_string ]]; then
@@ -477,13 +482,12 @@ create_battery_indicator () {
             battery_color=$colors_reset
         fi
         battery_indicator="$battery_color$battery_indicator$colors_reset"
-        unset battery_string battery_percent tmp
 }
 
 create_jobs_indicator() {
         # background jobs ⚒⚑⚐⚠
-        jobs_bkg=$(jobs -r)
-        jobs_stop=$(jobs -s)
+        local jobs_bkg=$(jobs -r)
+        local jobs_stop=$(jobs -s)
         if [[ -n $jobs_bkg || -n $jobs_stop ]]; then
             if [[ $utf8_prompt ]]; then
                 jobs_indicator="⚒"
@@ -504,6 +508,7 @@ check_make_status() {
 
         [[ $make_ignore_dir_list =~ $PWD ]] && return
 
+        local myrc
         if [[ -e Makefile ]]; then
             if [[ $utf8_prompt ]]; then
                 make_indicator="⚑"
@@ -517,7 +522,6 @@ check_make_status() {
             else
                 make_indicator="${!make_color_dirty}$make_indicator"
             fi
-            unset myrc
         else
             make_indicator=""
         fi
@@ -948,7 +952,7 @@ prompt_command_function() {
         # old static string with default order left here for reference
         ###PS1="$colors_reset$rc$virtualenv_string$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$make_indicator$prompt_color$prompt_char $colors_reset"
 
-        unset head_local pwd raw_rc space
+        unset head_local raw_rc
  }
 
         PROMPT_COMMAND=prompt_command_function

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -631,7 +631,7 @@ create_clock() {
             # U+1F55C (ONE-THIRTY) .. U+1F567 (TWELVE-THIRTY), for the thirties
             local clockfaces=(🕧 🕐 🕜 🕑 🕝 🕒 🕞 🕓 🕟 🕔 🕠 🕕 🕡 🕖 🕢 🕗 🕣 🕘 🕤 🕙 🕥 🕚 🕦 🕛)
             time_of_day=$((${current_time} - ${_gp_clock_timestamp_midnight}))
-            index=$(( (($time_of_day - 900) % 43200) / 1800 ))
+            index=$(( (($time_of_day - 4500) % 43200) / 1800 ))
             clock_indicator="${!clock_color}${clockfaces[$index]}${colors_reset}"
         else
             clock_indicator="${!clock_color}\t${colors_reset}"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -933,17 +933,18 @@ parse_vcs_status() {
         unset file_list
         local excl_mark='!'
         if [[ $count_only = "on" ]] ; then
-                [[ ${added_files[0]}      ]]  &&  file_list+=" "${added_vcs_color}+${#added_files[@]}
-                [[ ${deleted_files[0]}    ]]  &&  file_list+=" "${deleted_vcs_color}-${#deleted_files[@]}
-                [[ ${modified_files[0]}   ]]  &&  file_list+=" "${modified_vcs_color}*${#modified_files[@]}
-                [[ ${untracked_files[0]}  ]]  &&  file_list+=" "${untracked_vcs_color}?${#untracked_files[@]}
                 [[ ${conflicted_files[0]} ]]  &&  file_list+=" ${conflicted_vcs_color}${excl_mark}${#conflicted_files[@]}"
+                [[ ${modified_files[0]}   ]]  &&  file_list+=" "${modified_vcs_color}*${#modified_files[@]}
+                [[ ${deleted_files[0]}    ]]  &&  file_list+=" "${deleted_vcs_color}-${#deleted_files[@]}
+                [[ ${added_files[0]}      ]]  &&  file_list+=" "${added_vcs_color}+${#added_files[@]}
+                [[ ${untracked_files[0]}  ]]  &&  file_list+=" "${untracked_vcs_color}?${#untracked_files[@]}
         else
-                [[ ${added_files[0]}      ]]  &&  file_list+=" "$added_vcs_color${added_files[@]}
-                [[ ${deleted_files[0]}    ]]  &&  file_list+=" "$deleted_vcs_color${deleted_files[@]}
-                [[ ${modified_files[0]}   ]]  &&  file_list+=" "$modified_vcs_color${modified_files[@]}
-                [[ ${untracked_files[0]}  ]]  &&  file_list+=" "$untracked_vcs_color${untracked_files[@]}
                 [[ ${conflicted_files[0]} ]]  &&  file_list+=" "$conflicted_vcs_color${conflicted_files[@]}
+                [[ ${modified_files[0]}   ]]  &&  file_list+=" "$modified_vcs_color${modified_files[@]}
+                [[ ${deleted_files[0]}    ]]  &&  file_list+=" "$deleted_vcs_color${deleted_files[@]}
+                [[ ${added_files[0]}      ]]  &&  file_list+=" "$added_vcs_color${added_files[@]}
+                [[ ${untracked_files[0]}  ]]  &&  file_list+=" "$untracked_vcs_color${untracked_files[@]}
+
         fi
         [[ ${vim_files}          ]]  &&  file_list+=" "${MAGENTA}vim:${vim_files}
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -370,7 +370,7 @@ set_shell_label() {
         #then
         
         if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} ]]; then
-            probably_ssh_session=1 
+            probably_ssh_session=1
         else
             probably_ssh_session=
         fi
@@ -396,10 +396,10 @@ set_shell_label() {
 
         # abbreviate host name if needed
         # disregard setting and display full host if session is remote
-        if   [[ "$default_host_abbrev_mode" == "delete" && !$probably_ssh_session ]]
+        if   [[ "$default_host_abbrev_mode" == "delete" && -z $probably_ssh_session ]]
         then
             host=${host#$default_host}
-        elif [[ "$default_host_abbrev_mode" == "abbrev" && !$probably_ssh_session ]]
+        elif [[ "$default_host_abbrev_mode" == "abbrev" && -z $probably_ssh_session ]]
         then
             # only abbreviate if the abbreviated string is actually shorter than the full one
             if [[ "$host" == "$default_host" && ${#host} -ge $((${#ellipse_marker} + 1)) ]]

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -27,6 +27,7 @@
         battery_module=${battery_module:-off}
         make_module=${make_module:-off}
         jobs_module=${jobs_module:-on}
+        rc_module=${rc_module:-on}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
 
@@ -843,7 +844,7 @@ alias jumpstart='echo ${aj_dir_list[@]}'
 prompt_command_function() {
         rc="$?"
 
-        if [[ "$rc" == "0" ]]; then
+        if [[ "$rc_module" != "on" || "$rc" == "0" ]]; then
                 rc=""
         else
                 rc="$rc_color$rc$colors_reset$bell "

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -601,7 +601,7 @@ meas_command_time() {
 
 # TODO make this more configurable
 create_load_indicator () {
-        local load_color load_value load_str load_mark i j
+        local load_color load_value load_str load_bar load_mark i j
         local -a load_colors load_thresholds
         load_colors=(BLACK red RED whiteonred)
         load_thresholds=(100 200 300 400)
@@ -625,6 +625,14 @@ create_load_indicator () {
 
         if [[ $utf8_prompt ]]; then
             load_mark="☢"
+            local load_int=$((load_value / 100 - 1))
+            local load_frac=$((load_value % 100))
+            load_frac=$((load_frac / 13))
+            local -a load_chars=( " " "▏" "▎" "▍" "▌" "▋" "▊" "▉" "█" )
+            
+            printf -v load_str "%${load_int}s"
+            load_str=${load_str// /█} 
+            load_str+=${load_chars[$load_frac]}
         else
             load_mark="L"
         fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -102,6 +102,7 @@
         command_time_threshold=${command_time_threshold:-15}
         clock_style=${clock_style:-analog}
         clock_alert_interval=${clock_alert_interval:-30}
+        enable_utf8=${enable_utf8:-on}
 
         if [[ -z "$load_colors" || -z "$load_thresholds" || ${#load_colors[@]} -ne ${#load_thresholds[@]} ]]; then
             load_colors=(BLACK red RED whiteonred)
@@ -248,15 +249,20 @@
         ####################################################################  MARKERS
         ellipse_marker_utf8="…"
         ellipse_marker_plain="..."
-        if [[ ("$LC_CTYPE $LC_ALL $LANG" =~ "UTF" || $LANG =~ "utf") && $TERM != "linux" ]];  then
+
+_gp_check_utf8() {
+        if [[ $enable_utf8 == "on" && ("$LC_CTYPE $LC_ALL $LANG" =~ "UTF" || $LANG =~ "utf") && $TERM != "linux" ]];  then
                 utf8_prompt=1
                 ellipse_marker=$ellipse_marker_utf8
         else
                 utf8_prompt=
                 ellipse_marker=$ellipse_marker_plain
         fi
+}
 
-        export who_where
+_gp_check_utf8
+
+export who_where
 
 
 cwd_truncate() {
@@ -476,7 +482,8 @@ _gp_get_tty
         ## is sshd our parent?
         # if    { for ((pid=$$; $pid != 1 ; pid=`ps h -o pid --ppid $pid`)); do ps h -o command -p $pid; done | grep -q sshd && echo == REMOTE ==; }
         #then
-        
+
+_gp_get_host() {
         if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} || -n ${SSH_CONNECTION} ]]; then
             probably_ssh_session=1
             at_color=$at_color_remote
@@ -529,10 +536,14 @@ _gp_get_tty
         host=${host%.$default_domain}
 
         unset probably_ssh_session
+}
+
+_gp_get_host
 
 #################################################################### WHO_WHERE
         #  [[user@]host[-tty]]
 
+_gp_set_who_where() {
         if [[ -n $id  || -n $host ]] ;   then
                 [[ -n $id  &&  -n $host ]]  &&  at='@'  || at=''
                 color_who_where="${id//\\/\\\\}${host:+$at_color$at$host_color$host}${_gp_tty:+$_gp_tty}"
@@ -565,7 +576,9 @@ _gp_get_tty
             fi
             return 0
         fi
+}
 
+_gp_set_who_where
 
 create_battery_indicator () {
         # if not a laptop: :
@@ -1334,6 +1347,25 @@ prompt_OFF() {
 
         disable_set_shell_label
 }
+
+prompt_disable_utf8() {
+        enable_utf8="off"
+        _gp_check_utf8
+        _gp_get_id
+        _gp_get_tty
+        _gp_get_host
+        _gp_set_who_where
+}
+
+prompt_enable_utf8() {
+        enable_utf8="on"
+        _gp_check_utf8
+        _gp_get_id
+        _gp_get_tty
+        _gp_get_host
+        _gp_set_who_where
+}
+
 
         prompt_on
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -648,7 +648,7 @@ parse_svn_status() {
 
         case $svn_method in
             svnversion)  rev=$(svnversion)
-                         [[ "$rev" == "exported" ]] && return 1
+                         [[ "$rev" == "exported" || "$rev" =~ "Unversioned" ]] && return 1
                          ;;
 
             info)        svn_info_str=$(svn info 2> /dev/null)

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -403,15 +403,21 @@ set_shell_label() {
                 _gp_tmux_session=$(tmux display-message -p "#S")
             fi
 
-            # replace tty number with circled numbers
-            if [[ $utf8_prompt ]]; then
-                declare -a circled_digits=(⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⑩ ⑪ ⑫ ⑬ ⑭ ⑮ ⑯ ⑰ ⑱ ⑲ ⑳)
-                if [[ "$tty" -ge 0 && "$tty" -le 20 ]]; then
-                    tty="${circled_digits[$tty]} "
+            # if we start an ssh connection from within a screen/tmux session,
+            # the "screen" $TERM setting tends to be preserved.
+            # In this case we don't want a tty (it would be a misleading "0"),
+            # unless there is an actual screen/tmux session on the server too.
+            if [[ -n "$tty" ]]; then
+                # replace tty number with circled numbers
+                if [[ $utf8_prompt ]]; then
+                    declare -a circled_digits=(⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⑩ ⑪ ⑫ ⑬ ⑭ ⑮ ⑯ ⑰ ⑱ ⑲ ⑳)
+                    if [[ "$tty" -ge 0 && "$tty" -le 20 ]]; then
+                        tty="${circled_digits[$tty]} "
+                    fi
+                    unset circled_digits
+                else
+                    tty=" $tty"
                 fi
-                unset circled_digits
-            else
-                tty=" $tty"
             fi
         fi
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -151,9 +151,11 @@
         fi
 
         ####################################################################  MARKERS
-        if [[ "$LC_CTYPE $LC_ALL" =~ "UTF" && $TERM != "linux" ]];  then
+        if [[ ("$LC_CTYPE $LC_ALL" =~ "UTF" || $LANG =~ "utf") && $TERM != "linux" ]];  then
+                utf8_prompt=1
                 ellipse_marker="…"
         else
+                utf8_prompt=
                 ellipse_marker="..."
         fi
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -763,8 +763,9 @@ parse_svn_status() {
         local svn_info_str myrc rev
 
         case $svn_method in
-            svnversion)  rev=$(svnversion)
-                         [[ "$rev" == "exported" || "$rev" =~ "Unversioned" ]] && return 1
+            svnversion)  rev=$(svnversion 2> /dev/null)
+                         myrc=$?
+                         [[ $myrc -ne 0 || "$rev" == "exported" || "$rev" =~ "Unversioned" ]] && return 1
                          ;;
 
             info)        svn_info_str=$(svn info 2> /dev/null)
@@ -776,6 +777,8 @@ parse_svn_status() {
 
             dotsvn)      [[ -d .svn ]]              || return 1
                          svn_info_str=$(svn info 2> /dev/null)
+                         myrc=$?
+                         [[ $myrc -eq 0 ]]          || return 1
                          rev=${svn_info_str##*Revision: }
                          rev=${rev%%[[:space:]]*}
                          ;;

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -350,9 +350,6 @@ set_shell_label() {
         fi
 
         uphost=`echo ${host} | tr a-z-. A-Z_`
-        if [[ $upcase_hostname = "on" ]]; then
-                host=${uphost}
-        fi
 
         host_color=${uphost}_host_color
         host_color=${!host_color}
@@ -373,8 +370,11 @@ set_shell_label() {
             then
                 host="${host:0:1}$ellipse"
             fi
-        #else
-            # keep full host name
+        else
+            # set upcase hostname if needed
+            if [[ $upcase_hostname = "on" ]]; then
+                host=${uphost}
+            fi
         fi
 
         at_color=${!at_color}

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -334,7 +334,7 @@ set_shell_label() {
             # FIXME $STY not inherited though "su -"
             if [[ "$STY" ]]; then
                 # workaround screen UTF-8 bug
-                param=${param//$ellipse_marker/$ellipse_marker_plain}
+                short=${param//$ellipse_marker/$ellipse_marker_plain}
                 full=${full//$ellipse_marker/$ellipse_marker_plain}
             fi
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -388,7 +388,7 @@ set_shell_label() {
 
         if [[ -n $id  || -n $host ]] ;   then
                 [[ -n $id  &&  -n $host ]]  &&  at='@'  || at=''
-                color_who_where="${id}${host:+$at_color$at$host_color$host}${tty:+ $tty}"
+                color_who_where="${id//\\/\\\\}${host:+$at_color$at$host_color$host}${tty:+ $tty}"
                 plain_who_where="${id}$at$host"
 
                 # add trailing " "

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -396,6 +396,17 @@ set_shell_label() {
             elif [[ "$TMUX" ]]; then
                 tty=$(tmux display-message -p "#I")
             fi
+
+            # replace tty number with circled numbers
+            if [[ $utf8_prompt ]]; then
+                declare -a circled_digits=(⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⑩ ⑪ ⑫ ⑬ ⑭ ⑮ ⑯ ⑰ ⑱ ⑲ ⑳)
+                if [[ "$tty" -ge 0 && "$tty" -le 20 ]]; then
+                    tty="${circled_digits[$tty]} "
+                fi
+                unset circled_digits
+            else
+                tty=" $tty"
+            fi
         fi
 
         # we don't need tty name under X11
@@ -480,7 +491,7 @@ set_shell_label() {
 
         if [[ -n $id  || -n $host ]] ;   then
                 [[ -n $id  &&  -n $host ]]  &&  at='@'  || at=''
-                color_who_where="${id//\\/\\\\}${host:+$at_color$at$host_color$host}${tty:+ $tty}"
+                color_who_where="${id//\\/\\\\}${host:+$at_color$at$host_color$host}${tty:+$tty}"
                 plain_who_where="${id}$at$host"
 
                 # if root then make it root_color

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -627,7 +627,7 @@ create_clock() {
             [[ $(( ($current_time - ${_gp_clock_timestamp_last})/(60 * $clock_alert_interval) )) -eq 0 ]] && return
         fi
 
-        if [[ $clock_style == "analog" ]]; then
+        if [[ $clock_style == "analog" && $utf8_prompt ]]; then
             # unicode clock face characters
             # U+1F550 (ONE OCLOCK) .. U+1F55B (TWELVE OCLOCK), for the plain hours
             # U+1F55C (ONE-THIRTY) .. U+1F567 (TWELVE-THIRTY), for the thirties

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -515,10 +515,8 @@ create_battery_indicator () {
         # if laptop on battery: one of ▕▁▏▕▂▏▕▃▏▕▄▏▕▅▏▕▆▏▕▇▏▕█▏
         # color: red if power < 30 %, else normal
 
-        local battery_string
-        local battery_percent
-        local battery_color
-        local tmp
+        local battery_string battery_percent battery_color battery_pwr_index tmp
+        local -a battery_diagrams
         battery_string=$(acpi -b)
 
         if [[ $battery_string ]]; then
@@ -1107,7 +1105,7 @@ parse_vcs_status() {
  }
 
 parse_virtualenv_status() {
-    unset virtualenv
+    local virtualenv
 
     [[ $virtualenv_module = "on" ]] || return 1
 
@@ -1235,7 +1233,7 @@ prompt_command_function() {
         # old static string with default order left here for reference
         ###PS1="$colors_reset$rc$virtualenv_string$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$make_indicator$prompt_color$prompt_char $colors_reset"
 
-        unset head_local raw_rc jobs_indicator virtualenv_string make_indicator battery_indicator command_time load_indicator
+        unset head_local raw_rc jobs_indicator virtualenv_string make_indicator battery_indicator command_time load_indicator clock_indicator
  }
 
 # provide functions to turn the fancy prompt functions on and off

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -5,7 +5,7 @@
 
         #####  read config file if any.
 
-        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop
+        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
         unset modified_vcs_color added_vcs_color addmoded_vcs_color untracked_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
         unset rawhex_len
@@ -43,6 +43,7 @@
         cols=`tput colors`                              # in emacs shell-mode tput colors returns -1
         if [[ -n "$cols" && $cols -ge 8 ]];  then       #  if terminal supports colors
                 dir_color=${dir_color:-CYAN}
+                slash_color=${slash_color:-CYAN}
                 rc_color=${rc_color:-red}
                 virtualenv_color=${virtualenv_color:-green}
                 user_id_color=${user_id_color:-blue}
@@ -304,6 +305,7 @@ set_shell_label() {
         esac
 
         dir_color=${!dir_color}
+        slash_color=${!slash_color}
         rc_color=${!rc_color}
         virtualenv_color=${!virtualenv_color}
         user_id_color=${!user_id_color}
@@ -842,6 +844,8 @@ prompt_command_function() {
         # if cwd_cmd have back-slash, then assign it value to cwd
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
+
+        cwd=${cwd//\//$slash_color\/$dir_color}
 
         PS1="$colors_reset$rc$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$tail_local$make_indicator$dir_color$prompt_char $colors_reset"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -296,7 +296,7 @@ set_shell_label() {
             # only abbreviate if the abbreviated string is actually shorter than the full one
             if [[ "$id" == "$default_user" && ${#id} -ge $((${#ellipse_marker} + 1)) ]]
             then
-                id="${id:0:1}$ellipse"
+                id="${id:0:1}$ellipse_marker"
             fi
         #else
             # keep full user name
@@ -368,7 +368,7 @@ set_shell_label() {
             # only abbreviate if the abbreviated string is actually shorter than the full one
             if [[ "$host" == "$default_host" && ${#host} -ge $((${#ellipse_marker} + 1)) ]]
             then
-                host="${host:0:1}$ellipse"
+                host="${host:0:1}$ellipse_marker"
             fi
         else
             # set upcase hostname if needed

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -577,11 +577,14 @@ _gp_set_who_where() {
             else
                 PS1="\w$prompt_char "
             fi
-            return 0
+            return 1
         fi
 }
 
 _gp_set_who_where
+
+# exit if in mc (see above)
+[[ $? -ne 0 ]] && return 1
 
 create_battery_indicator () {
         # if not a laptop: :

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -336,7 +336,7 @@ set_shell_label() {
         tty=`echo $tty | sed "s:/dev/pts/:p:; s:/dev/tty::" `           # RH tty devs
         tty=`echo $tty | sed "s:/dev/vc/:vc:" `                         # gentoo tty devs
 
-        if [[ "$TERM" = "screen" ]] ;  then
+        if [[ "$TERM" =~ "screen" ]] ;  then
 
                 #       [ "$WINDOW" = "" ] && WINDOW="?"
                 #

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -790,8 +790,6 @@ parse_vcs_status() {
 
         ### fringes
         head_local="${head_local+$vcs_color$head_local }"
-        #above_local="${head_local+$vcs_color$head_local\n}"
-        #tail_local="${tail_local+$vcs_color $tail_local}${dir_color}"
  }
 
 parse_virtualenv_status() {
@@ -888,9 +886,9 @@ prompt_command_function() {
 
         cwd=${cwd//\//$slash_color\/$dir_color}
 
-        PS1="$colors_reset$rc$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$tail_local$make_indicator$prompt_color$prompt_char $colors_reset"
+        PS1="$colors_reset$rc$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$make_indicator$prompt_color$prompt_char $colors_reset"
 
-        unset head_local tail_local pwd raw_rc
+        unset head_local pwd raw_rc
  }
 
         PROMPT_COMMAND=prompt_command_function

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -5,7 +5,7 @@
 
         #####  read config file if any.
 
-        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color at_color at_color_remote
+        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color slash_color_readonly at_color at_color_remote
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
         unset modified_vcs_color added_vcs_color untracked_vcs_color deleted_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
         unset rawhex_len
@@ -49,6 +49,7 @@
         if [[ -n "$cols" && $cols -ge 8 ]];  then       #  if terminal supports colors
                 dir_color=${dir_color:-CYAN}
                 slash_color=${slash_color:-CYAN}
+                slash_color_readonly=${slash_color_readonly:-MAGENTA}
                 prompt_color=${prompt_color:-white}
                 rc_color=${rc_color:-red}
                 virtualenv_color=${virtualenv_color:-green}
@@ -370,6 +371,7 @@ set_shell_label() {
 
         dir_color=${!dir_color}
         slash_color=${!slash_color}
+        slash_color_readonly=${!slash_color_readonly}
         prompt_color=${!prompt_color}
         rc_color=${!rc_color}
         virtualenv_color=${!virtualenv_color}
@@ -992,7 +994,7 @@ prompt_command_function() {
         cwd=${PWD/$HOME/\~}                     # substitute  "~"
         set_shell_label "${cwd##[/~]*/}/"       # default label - path last dir
 
-	parse_virtualenv_status
+        parse_virtualenv_status
         parse_vcs_status
 
         if [[ $battery_module == "on" ]]; then
@@ -1022,7 +1024,12 @@ prompt_command_function() {
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
 
-        cwd=${cwd//\//$slash_color\/$dir_color}
+
+        if [[ -w "$PWD" ]]; then
+            cwd=${cwd//\//$slash_color\/$dir_color}
+        else
+            cwd=${cwd//\//$slash_color_readonly\/$dir_color}
+        fi
 
         # in effect, echo collapses spaces inside the string and removes them from the start/end
         local prompt_command_string_l

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -651,7 +651,7 @@ parse_hg_status() {
             local hg_heads
             hg_heads=$(hg heads --template '{rev}\n' $branch | wc -l)
 
-            if [[ hg_heads -gt 1 ]]; then
+            if [[ $hg_heads -gt 1 ]]; then
                 detached=detached
                 local excl_mark='!'
                 vcs_info="$detached_vcs_color$hg_heads$excl_mark$vcs_info"
@@ -659,10 +659,21 @@ parse_hg_status() {
         fi
 
         local hg_vcs_char
+        local hg_up_char
         if [[ $utf8_prompt ]]; then
             hg_vcs_char="☿"
+            hg_up_char="↑"
         else
             hg_vcs_char=":"
+            hg_up_char="^"
+        fi
+
+        local hg_tags
+        local tip_regex
+        hg_tags=$(hg id -t)
+        tip_regex=\\btip\\b
+        if [[ ! $hg_tags =~ $tip_regex ]]; then
+            vcs_info+="$WHITE$hg_up_char"
         fi
 
         local hg_revision

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -339,7 +339,7 @@ set_shell_label() {
             fi
 
             if [[ "$TMUX" ]]; then
-                full="$plain_who_where|${_gp_tmux_session} $@"
+                full="$plain_who_where${_gp_tmux_session:+|${_gp_tmux_session}} $@"
             fi
 
             # FIXME: run this only if screen is in xterm (how to test for this?)

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -342,9 +342,15 @@ set_shell_label() {
         full="$plain_who_where $@"
         short="$*"
 
+        # hack to replace garbled bash command under mc on some systems
+        if [[ "$short" == ". /usr/libexec/mc/mc-wrapper.sh" ]]; then
+             short="mc"
+             full="$plain_who_where $short"
+        fi
+
         xterm_label() {
              local args="$*"
-             printf "\033]0;%s\033\\" "${args:0:200}"
+             printf "\033]0;%s\007" "${args:0:200}"
         }
 
         screen_label() {
@@ -357,7 +363,7 @@ set_shell_label() {
             fi
 
             if [[ "$TMUX" ]]; then
-                full="$plain_who_where${_gp_tmux_session:+|${_gp_tmux_session}} $@"
+                full="$plain_who_where${_gp_tmux_session:+|${_gp_tmux_session}} $short"
             fi
 
             # FIXME: run this only if screen is in xterm (how to test for this?)

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -798,8 +798,10 @@ parse_virtualenv_status() {
     [[ $virtualenv_module = "on" ]] || return 1
 
     if [[ -n "$VIRTUAL_ENV" ]] ; then
-	virtualenv=`basename $VIRTUAL_ENV`
-	rc="$rc $virtualenv_color<$virtualenv> "
+        virtualenv=`basename $VIRTUAL_ENV`
+        virtualenv_string=" $virtualenv_color<$virtualenv> "
+    else
+        virtualenv_string=""
     fi
  }
 
@@ -886,7 +888,7 @@ prompt_command_function() {
 
         cwd=${cwd//\//$slash_color\/$dir_color}
 
-        PS1="$colors_reset$rc$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$make_indicator$prompt_color$prompt_char $colors_reset"
+        PS1="$colors_reset$rc$virtualenv_string$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$make_indicator$prompt_color$prompt_char $colors_reset"
 
         unset head_local pwd raw_rc
  }

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -1208,8 +1208,10 @@ prompt_command_function() {
         fi
         previous_rc="$raw_rc"
 
-        cwd=${PWD/$HOME/\~}                     # substitute  "~"
-        set_shell_label "${cwd##[/~]*/}/"       # default label - path last dir
+        local slash='/'
+        cwd=${PWD/$HOME/\~}                           # substitute  "~"
+        cwd="${cwd##[/~]*/}/"                         # default label - path last dir
+        set_shell_label "${cwd/$slash$slash/$slash}"  # remove // if root dir
 
         parse_virtualenv_status
         parse_vcs_status
@@ -1259,7 +1261,6 @@ prompt_command_function() {
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
 
-        local slash='/'
         if [[ -w "$PWD" ]]; then
             cwd="${cwd//$slash/$slash_color$slash$dir_color}"
         else

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -1043,9 +1043,38 @@ prompt_command_function() {
         unset head_local raw_rc
  }
 
+# provide functions to turn the fancy prompt functions on and off
+# off: return to old (distro default) prompt
+# OFF: plain $
+# idea taken from liquidprompt: https://github.com/nojhan/liquidprompt
+prompt_on() {
+        if [[ -z $GIT_PROMPT_ON ]]; then
+            OLD_PS1="$PS1"
+            OLD_PROMPT_COMMAND="$PROMPT_COMMAND"
+        fi
+
         PROMPT_COMMAND=prompt_command_function
 
         enable_set_shell_label
+
+        GIT_PROMPT_ON=1
+}
+
+prompt_off() {
+        PROMPT_COMMAND="$OLD_PROMPT_COMMAND"
+        PS1="$OLD_PS1"
+
+        disable_set_shell_label
+}
+
+prompt_OFF() {
+        PROMPT_COMMAND="$OLD_PROMPT_COMMAND"
+        PS1="\$ "
+
+        disable_set_shell_label
+}
+
+        prompt_on
 
         unset rc id tty modified_files file_list
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -606,10 +606,9 @@ create_load_indicator () {
         load_colors=(BLACK red RED whiteonred)
         load_thresholds=(100 200 300 400)
 
-        load_str=$(uptime)
-        load_str=${load_str:45:4}
+        load_str=$(uptime | sed -ne 's/.* load average: \([0-9]\.[0-9]\{1,2\}\).*/\1/p')
         load_value=${load_str/\./}
-        load_value=${load_value#0}
+        load_value=${load_value##0}
 
         if [[ $load_value -lt ${load_thresholds[0]} ]]; then 
             load_indicator=""

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -212,6 +212,18 @@
               deleted_vcs_color=${!deleted_vcs_color}
                   hex_vcs_color=${!hex_vcs_color}
 
+                      dir_color=${!dir_color}
+                    slash_color=${!slash_color}
+           slash_color_readonly=${!slash_color_readonly}
+                   prompt_color=${!prompt_color}
+                       rc_color=${!rc_color}
+               virtualenv_color=${!virtualenv_color}
+                  user_id_color=${!user_id_color}
+                  root_id_color=${!root_id_color}
+                       at_color=${!at_color}
+                at_color_remote=${!at_color_remote}
+
+
         unset PROMPT_COMMAND
 
         # assemble prompt command string based on the module order specified above
@@ -465,15 +477,6 @@ _gp_get_tty() {
 
 _gp_get_tty
 
-        dir_color=${!dir_color}
-        slash_color=${!slash_color}
-        slash_color_readonly=${!slash_color_readonly}
-        prompt_color=${!prompt_color}
-        rc_color=${!rc_color}
-        virtualenv_color=${!virtualenv_color}
-        user_id_color=${!user_id_color}
-        root_id_color=${!root_id_color}
-
         ########################################################### HOST
         ### we don't display home host/domain  $SSH_* set by SSHD or keychain
 
@@ -486,9 +489,10 @@ _gp_get_tty
 _gp_get_host() {
         if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} || -n ${SSH_CONNECTION} ]]; then
             probably_ssh_session=1
-            at_color=$at_color_remote
+            at_color_cur=$at_color_remote
         else
             probably_ssh_session=
+            at_color_cur=$at_color
         fi
 
         host=${HOSTNAME}
@@ -529,11 +533,10 @@ _gp_get_host() {
             fi
         fi
 
-        at_color=${!at_color}
         host_color=${!host_color}
 
         # we might already have short host name
-        host=${host%.$default_domain}
+        [[ -n $default_domain ]] && host=${host%.$default_domain}
 
         unset probably_ssh_session
 }
@@ -546,7 +549,7 @@ _gp_get_host
 _gp_set_who_where() {
         if [[ -n $id  || -n $host ]] ;   then
                 [[ -n $id  &&  -n $host ]]  &&  at='@'  || at=''
-                color_who_where="${id//\\/\\\\}${host:+$at_color$at$host_color$host}${_gp_tty:+$_gp_tty}"
+                color_who_where="${id//\\/\\\\}${host:+$at_color_cur$at$host_color$host}${_gp_tty:+$_gp_tty}"
                 plain_who_where="${id}$at$host"
 
                 # if root then make it root_color

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -5,7 +5,7 @@
 
         #####  read config file if any.
 
-        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color
+        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color at_color
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
         unset modified_vcs_color added_vcs_color addmoded_vcs_color untracked_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
         unset rawhex_len
@@ -48,6 +48,7 @@
                 virtualenv_color=${virtualenv_color:-green}
                 user_id_color=${user_id_color:-blue}
                 root_id_color=${root_id_color:-magenta}
+                at_color=${at_color:-green}
                 jobs_color_bkg=${jobs_color:-yellow}
                 jobs_color_stop=${jobs_color:-red}
                 make_color_ok=${make_color_ok:-BLACK}
@@ -342,6 +343,7 @@ set_shell_label() {
                 host_color=${color_index[cksum_color_no]}
         fi
 
+        at_color=${!at_color}
         host_color=${!host_color}
 
         # we might already have short host name
@@ -352,7 +354,7 @@ set_shell_label() {
 
         if [[ -n $id  || -n $host ]] ;   then
                 [[ -n $id  &&  -n $host ]]  &&  at='@'  || at=''
-                color_who_where="${id}${host:+$host_color$at$host}${tty:+ $tty}"
+                color_who_where="${id}${host:+$at_color$at$host_color$host}${tty:+ $tty}"
                 plain_who_where="${id}$at$host"
 
                 # add trailing " "

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -999,6 +999,8 @@ parse_git_status() {
                                 s,^.U \"\([^/]\+/\?\).*\"$,        conflicted_files+=(\"\1\"),p
                                 s,^D. \([^\"][^/]*/\?\).*,            deleted_files+=(\"\1\"),p
                                 s,^D. \"\([^/]\+/\?\).*\"$,           deleted_files+=(\"\1\"),p
+                                s,^.D \([^\"][^/]*/\?\).*,            deleted_files+=(\"\1\"),p
+                                s,^.D \"\([^/]\+/\?\).*\"$,           deleted_files+=(\"\1\"),p
                                 s,^[MARC]. \([^\"][^/]*/\?\).*,         added_files+=(\"\1\"),p
                                 s,^[MARC]. \"\([^/]\+/\?\).*\"$,        added_files+=(\"\1\"),p
                                 s,^.[MA] \([^\"][^/]*/\?\).*,        modified_files+=(\"\1\"),p

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -92,7 +92,7 @@
                    op_vcs_color=${op_vcs_color:-MAGENTA}
              detached_vcs_color=${detached_vcs_color:-RED}
 
-                  hex_vcs_color=${hex_vcs_color:-BLACK}         # gray
+                  hex_vcs_color=${hex_vcs_color:-dim}         # gray
 
 
         max_file_list_length=${max_file_list_length:-100}
@@ -194,7 +194,7 @@
 
          whiteonred='\['`tput setaf 7; tput setab 1; tput bold`'\]'
 
-                dim='\['`tput sgr0; tput setaf p1`'\]'  # half-bright
+                dim='\['`tput sgr0; tput dim`'\]'  # half-bright
 
             bw_bold='\['`tput bold`'\]'
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -621,13 +621,13 @@ parse_svn_status() {
         unset status modified added clean init deleted untracked conflicted op detached
         eval `svn status 2>/dev/null |
                 sed -n '
-                    s/^A...    \([^.].*\)/added=added;           added_files[${#added_files[@]}]=\"\1\";/p
-                    s/^M...    \([^.].*\)/modified=modified;     modified_files[${#modified_files[@]}]=\"\1\";/p
+                    s/^A...    \([^.].*\)/added=added;                added_files+=(\"\1\");/p
+                    s/^M...    \([^.].*\)/modified=modified;       modified_files+=(\"\1\");/p
                     s/^R...    \([^.].*\)/added=added;/p
-                    s/^D...    \([^.].*\)/deleted=deleted;       deleted_files[${#deleted_files[@]}]=\"\1\";/p
-                    s/^C...    \([^.].*\)/conflicted=conflicted; conflicted_files[${#conflicted_files[@]}]=\"\1\";/p
-                    s/^\!...    \([^.].*\)/deleted=deleted;      deleted_files[${#deleted_files[@]}]=\"\1\";/p
-                    s/^\?...    \([^.].*\)/untracked=untracked;  untracked_files[${#untracked_files[@]}]=\"\1\";/p
+                    s/^D...    \([^.].*\)/deleted=deleted;          deleted_files+=(\"\1\");/p
+                    s/^C...    \([^.].*\)/conflicted=conflicted; conflicted_files+=(\"\1\");/p
+                    s/^\!...    \([^.].*\)/deleted=deleted;         deleted_files+=(\"\1\");/p
+                    s/^\?...    \([^.].*\)/untracked=untracked;   untracked_files+=(\"\1\");/p
                 '
         `
         # TODO branch detection if standard repo layout

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -206,12 +206,14 @@
         fi
 
         ####################################################################  MARKERS
+        ellipse_marker_utf8="…"
+        ellipse_marker_plain="..."
         if [[ ("$LC_CTYPE $LC_ALL $LANG" =~ "UTF" || $LANG =~ "utf") && $TERM != "linux" ]];  then
                 utf8_prompt=1
-                ellipse_marker="…"
+                ellipse_marker=$ellipse_marker_utf8
         else
                 utf8_prompt=
-                ellipse_marker="..."
+                ellipse_marker=$ellipse_marker_plain
         fi
 
         export who_where
@@ -285,8 +287,13 @@ set_shell_label() {
         }
 
         screen_label() {
+		local param
+		param="$plain_who_where $@"
+		# workaround screen UTF-8 bug
+		param=${param//$ellipse_marker/$ellipse_marker_plain}
+
                 # FIXME: run this only if screen is in xterm (how to test for this?)
-                xterm_label  "$plain_who_where $@"
+                xterm_label  "$param"
 
                 # FIXME $STY not inherited though "su -"
                 [ "$STY" ] && screen -S $STY -X title "$*"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -970,9 +970,9 @@ parse_git_status() {
                         s/^\(# \)*On branch /branch=/p
                         s/^nothing to commi.*/clean=clean/p
                         s/^\(# \)*Initial commi.*/init=init/p
-                        s/^\(# \)*Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}${git_up_char}/p
-                        s/^\(# \)*Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}${git_dn_char}/p
-                        s/^\(# \)*Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}${git_updn_char}/p
+                        s/^\(# \)*Your branch is ahead of \(.\).\+\2 by [[:digit:]]\+ commit.*/freshness=${WHITE}${git_up_char}/p
+                        s/^\(# \)*Your branch is behind \(.\).\+\2 by [[:digit:]]\+ commit.*/freshness=${YELLOW}${git_dn_char}/p
+                        s/^\(# \)*Your branch and \(.\).\+\2 have diverged.*/freshness=${YELLOW}${git_updn_char}/p
                     '
         )"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -368,6 +368,12 @@ set_shell_label() {
         ## is sshd our parent?
         # if    { for ((pid=$$; $pid != 1 ; pid=`ps h -o pid --ppid $pid`)); do ps h -o command -p $pid; done | grep -q sshd && echo == REMOTE ==; }
         #then
+        
+        if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} ]]; then
+            probably_ssh_session=1 
+        else
+            probably_ssh_session=
+        fi
 
         host=${HOSTNAME}
         if [[ $short_hostname = "on" ]]; then
@@ -389,10 +395,11 @@ set_shell_label() {
         fi
 
         # abbreviate host name if needed
-        if   [[ "$default_host_abbrev_mode" == "delete" ]]
+        # disregard setting and display full host if session is remote
+        if   [[ "$default_host_abbrev_mode" == "delete" && !$probably_ssh_session ]]
         then
             host=${host#$default_host}
-        elif [[ "$default_host_abbrev_mode" == "abbrev" ]]
+        elif [[ "$default_host_abbrev_mode" == "abbrev" && !$probably_ssh_session ]]
         then
             # only abbreviate if the abbreviated string is actually shorter than the full one
             if [[ "$host" == "$default_host" && ${#host} -ge $((${#ellipse_marker} + 1)) ]]
@@ -411,6 +418,8 @@ set_shell_label() {
 
         # we might already have short host name
         host=${host%.$default_domain}
+
+        unset probably_ssh_session
 
 #################################################################### WHO_WHERE
         #  [[user@]host[-tty]]

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -607,9 +607,9 @@ create_battery_indicator () {
         battery_string=$(acpi -b)
 
         if [[ $battery_string ]]; then
-            tmp=${battery_string%\%*}
+            tmp=${battery_string%%\%*}
             battery_percent=${tmp##* }
-            if [[ "$battery_string" =~ "Discharging" ]]; then
+            if [[ "$tmp" =~ "Discharging" ]]; then
                 if [[ $utf8_prompt ]]; then
                     battery_diagrams=( ▕▁▏ ▕▂▏ ▕▃▏ ▕▄▏ ▕▅▏ ▕▆▏ ▕▇▏ ▕█▏ )
                     battery_pwr_index=$(($battery_percent/13))
@@ -617,7 +617,7 @@ create_battery_indicator () {
                 else
                     battery_indicator="|$battery_percent|"
                 fi
-            elif [[ "$battery_string" =~ "Charging" ]]; then
+            elif [[ "$tmp" =~ "Charging" ]]; then
                 if [[ $utf8_prompt ]]; then
                     battery_indicator="▕⚡▏"
                 else

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -511,9 +511,9 @@ create_jobs_indicator() {
                 jobs_indicator="%"
             fi
             if [[ -n $jobs_stop ]]; then
-                jobs_indicator="${!jobs_color_stop}$jobs_indicator"
+                jobs_indicator="${!jobs_color_stop}$jobs_indicator$colors_reset"
             else
-                jobs_indicator="${!jobs_color_bkg}$jobs_indicator"
+                jobs_indicator="${!jobs_color_bkg}$jobs_indicator$colors_reset"
             fi
         else
             jobs_indicator=""

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -524,6 +524,11 @@ check_make_status() {
 }
 
 parse_svn_status() {
+        # FIXME: SVN >= 1.7 uses a single .svn dir in the repository toplevel dir (like hg or git)
+        # instead of a .svn in each tracked dir, so the method below will not work!
+        # Unfortunately there is no easy fix, because svn doesn't have the equivalent of "hg root"
+        # or "git rev-parse", not to mention that it's possible to just check out a subdirectory of a repo,
+        # and different levels of a directory tree can belong to different checkouts.
 
         [[   -d .svn  ]] || return 1
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -895,7 +895,7 @@ parse_hg_status() {
 
         if [[ $hg_multiple_heads_display == "on" ]]; then
             local hg_heads
-            hg_heads=$(hg heads --template '{rev}\n' $branch | wc -l)
+            hg_heads=$(hg heads --template '{rev}\n' $branch 2> /dev/null | wc -l)
 
             if [[ $hg_heads -gt 1 ]]; then
                 detached=detached

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -32,13 +32,14 @@
         command_time_module=${command_time_module:-on}
         load_module=${load_module:-on}
         clock_module=${clock_module:-off}
+        sudo_module=${sudo_module:-off}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
 
         default_host_abbrev_mode=${default_host_abbrev_mode:-delete}
         default_id_abbrev_mode=${default_id_abbrev_mode:-delete}
 
-        prompt_modules_order=${prompt_modules_order:-RC LOAD CTIME VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE}
+        prompt_modules_order=${prompt_modules_order:-RC LOAD CTIME VIRTUALENV VCS SUDO WHO_WHERE JOBS BATTERY CWD MAKE}
 
         #### check for acpi, make, disable corresponding module if not installed
         if [[ -z $(which acpi 2> /dev/null) || -z $(acpi -b) ]]; then
@@ -67,6 +68,7 @@
                 make_color_dirty=${make_color_dirty:-RED}
                 command_time_color=${command_time_color:-YELLOW}
                 clock_color=${clock_color:-BLACK}
+                sudo_color=${sudo_color:-RED}
 
         else                                            #  only B/W
                 dir_color=${dir_color:-bw_bold}
@@ -246,6 +248,7 @@
                 s/BATTERY/\$battery_indicator/;
                 s/CWD/\$dir_color\$cwd/;
                 s/MAKE/\$make_indicator/;
+                s/SUDO/\$sudo_marker/;
                 s/ //g;
                 s/\$space\$space/\$space/g;
                 s/^\$space//;
@@ -766,6 +769,15 @@ create_load_indicator () {
         if [[ $load_display_style == "markonly" ]]; then load_str= ; fi
 
         load_indicator="$load_color$load_mark$load_str$colors_reset"
+}
+
+create_sudo_marker() {
+         sudo_marker=
+         if [[ $utf8_prompt ]]; then
+             sudo -nl &> /dev/null && sudo_marker="${!sudo_color}⚷$colors_reset"
+         else
+             sudo -nl &> /dev/null && sudo_marker="${!sudo_color}!$colors_reset"
+         fi
 }
 
 parse_svn_status() {
@@ -1322,6 +1334,12 @@ prompt_command_function() {
              clock_indicator=""
         fi
 
+        if [[ $sudo_module == "on" ]]; then
+             create_sudo_marker
+        else
+             sudo_marker=""
+        fi
+
         # autojump
         if [[ ${aj_dir_list[aj_idx%aj_max]} != $PWD ]] ; then
               aj_dir_list[++aj_idx%aj_max]="$PWD"
@@ -1346,7 +1364,7 @@ prompt_command_function() {
         # old static string with default order left here for reference
         ###PS1="$colors_reset$rc$virtualenv_string$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$make_indicator$prompt_color$prompt_char $colors_reset"
 
-        unset head_local raw_rc jobs_indicator virtualenv_string make_indicator battery_indicator command_time load_indicator clock_indicator
+        unset head_local raw_rc jobs_indicator virtualenv_string make_indicator battery_indicator command_time load_indicator clock_indicator sudo_marker
  }
 
 # provide functions to turn the fancy prompt functions on and off

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -967,12 +967,12 @@ parse_git_status() {
         eval " $(
                 LANG=C git status 2>/dev/null |
                     sed -n '
-                        s/^# On branch /branch=/p
+                        s/^\(# \)*On branch /branch=/p
                         s/^nothing to commi.*/clean=clean/p
-                        s/^# Initial commi.*/init=init/p
-                        s/^# Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}${git_up_char}/p
-                        s/^# Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}${git_dn_char}/p
-                        s/^# Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}${git_updn_char}/p
+                        s/^\(# \)*Initial commi.*/init=init/p
+                        s/^\(# \)*Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}${git_up_char}/p
+                        s/^\(# \)*Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}${git_dn_char}/p
+                        s/^\(# \)*Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}${git_updn_char}/p
                     '
         )"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -281,7 +281,7 @@ set_shell_label() {
 
         xterm_label() {
                 local args="$*"
-                echo  -n "]2;${args:0:200}" ;    # FIXME: replace hardcodes with terminfo codes
+                printf "\033]0;%s\033\\" "${args:0:200}"
         }
 
         screen_label() {

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -857,19 +857,19 @@ prompt_command_function() {
 	parse_virtualenv_status
         parse_vcs_status
 
-        if [[ $battery_module = "on" ]]; then
+        if [[ $battery_module == "on" ]]; then
              create_battery_indicator
         else
              battery_indicator=":"
         fi
 
-        if [[ $make_module = "on" ]]; then
+        if [[ $make_module == "on" ]]; then
              check_make_status
         else
              make_indicator=""
         fi
 
-        if [[ $jobs_module = "on" ]]; then
+        if [[ $jobs_module == "on" ]]; then
              create_jobs_indicator
         else
              jobs_indicator=""

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -445,16 +445,11 @@ _gp_get_tty() {
                 # and window number, to display it in the prompt
                 # TODO configurable prompt marker
                 # we have to do it like this, because session name may contain spaces
-                local sep tmux_info oldIFS
-                sep=$'\x1f'
+                local sep tmux_info
+                sep="~@~"  # used to be \x1f, bug tmux escapes arguments now
                 tmux_info=$(tmux display-message -t $TMUX_PANE -p "#S${sep}#I" 2> /dev/null)
-                oldIFS="$IFS"
-                IFS="$sep"
-                local -a tmux_array
-                tmux_array=($tmux_info)
-                IFS="$oldIFS"
-                _gp_tmux_session=${tmux_array[0]}
-                tty=${tmux_array[1]}
+                _gp_tmux_session=${tmux_info/$sep*/}
+                tty=${tmux_info/*$sep/}
             else
                 tty=
             fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -1061,11 +1061,11 @@ prompt_command_function() {
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
 
-
+        local slash='/'
         if [[ -w "$PWD" ]]; then
-            cwd=${cwd//\//$slash_color\/$dir_color}
+            cwd="${cwd//$slash/$slash_color$slash$dir_color}"
         else
-            cwd=${cwd//\//$slash_color_readonly\/$dir_color}
+            cwd="${cwd//$slash/$slash_color_readonly$slash$dir_color}"
         fi
 
         # in effect, echo collapses spaces inside the string and removes them from the start/end

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -635,6 +635,7 @@ parse_hg_status() {
                    hg_revision="$hex_vcs_color$hg_vcs_char${hg_revision:0:$rawhex_len}"
                    ;;
             num)   hg_revision=$(hg id -n)
+                   hg_vcs_char="#"
                    hg_revision="$hex_vcs_color$hg_vcs_char$hg_revision"
                    ;;
             *)     hg_revision="" ;;

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -842,13 +842,14 @@ alias jumpstart='echo ${aj_dir_list[@]}'
 ###################################################################### PROMPT_COMMAND
 
 prompt_command_function() {
-        rc="$?"
+        raw_rc="$?"
 
-        if [[ "$rc_module" != "on" || "$rc" == "0" ]]; then
+        if [[ "$rc_module" != "on" || "$raw_rc" == "0" || "$previous_rc" == "$raw_rc" ]]; then
                 rc=""
         else
-                rc="$rc_color$rc$colors_reset$bell "
+                rc="$rc_color$raw_rc$colors_reset$bell "
         fi
+        previous_rc="$raw_rc"
 
         cwd=${PWD/$HOME/\~}                     # substitute  "~"
         set_shell_label "${cwd##[/~]*/}/"       # default label - path last dir
@@ -887,7 +888,7 @@ prompt_command_function() {
 
         PS1="$colors_reset$rc$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$tail_local$make_indicator$prompt_color$prompt_char $colors_reset"
 
-        unset head_local tail_local pwd
+        unset head_local tail_local pwd raw_rc
  }
 
         PROMPT_COMMAND=prompt_command_function

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -837,10 +837,12 @@ parse_git_status() {
             git_up_char="↑"
             git_dn_char="↓"
             git_updn_char="↕"
+            git_stash_char="☡";
         else
             git_up_char="^"
             git_dn_char="v"
             git_updn_char="*"
+            git_stash_char="$"
         fi
 
 
@@ -954,6 +956,10 @@ parse_git_status() {
                         # branch=$(git symbolic-ref -q HEAD || { echo -n "detached:" ; git name-rev --name-only HEAD 2>/dev/null; } )
                         # branch=${branch#refs/heads/}
 
+        ### stash
+        local stash_num
+        stash_num=$(git stash list 2>/dev/null | wc -l)
+
         ### compose vcs_info
 
         if [[ $init ]];  then
@@ -973,6 +979,9 @@ parse_git_status() {
                 fi
                 vcs_info="$branch$freshness$rawhex"
 
+                if [[ $stash_num -gt 0 ]]; then
+                    vcs_info+="${white}$git_stash_char$stash_num"
+                fi
         fi
  }
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -338,6 +338,10 @@ set_shell_label() {
                 full=${full//$ellipse_marker/$ellipse_marker_plain}
             fi
 
+            if [[ "$TMUX" ]]; then
+                full="$plain_who_where|${_gp_tmux_session} $@"
+            fi
+
             # FIXME: run this only if screen is in xterm (how to test for this?)
             xterm_label "$full"
 
@@ -395,6 +399,8 @@ set_shell_label() {
                 tty="$WINDOW"
             elif [[ "$TMUX" ]]; then
                 tty=$(tmux display-message -p "#I")
+                # also save tmux session name so that we can include it in the window title
+                _gp_tmux_session=$(tmux display-message -p "#S")
             fi
 
             # replace tty number with circled numbers

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -431,6 +431,17 @@ parse_git_status() {
 
         unset branch status modified added clean init added mixed untracked op detached
 
+        if [[ $utf8_prompt ]]; then
+            git_up_char="↑"
+            git_dn_char="↓"
+            git_updn_char="↕"
+        else
+            git_up_char="^"
+            git_dn_char="v"
+            git_updn_char="*"
+        fi
+
+
 	# info not in porcelain status
         eval " $(
                 git status 2>/dev/null |
@@ -438,9 +449,9 @@ parse_git_status() {
                         s/^# On branch /branch=/p
                         s/^nothing to commi.*/clean=clean/p
                         s/^# Initial commi.*/init=init/p
-                        s/^# Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}↑/p
-                        s/^# Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}↓/p
-                        s/^# Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}↕/p
+                        s/^# Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}${git_up_char}/p
+                        s/^# Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}${git_dn_char}/p
+                        s/^# Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}${git_updn_char}/p
                     '
         )"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -37,7 +37,7 @@
         prompt_modules_order=${prompt_modules_order:-RC VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE}
 
         #### check for acpi, make, disable corresponding module if not installed
-        if [[ -z $(which acpi) && -z $(acpi -b) ]]; then
+        if [[ -z $(which acpi) || -z $(acpi -b) ]]; then
             battery_module=off
         fi
         if [[ -z $(which make) ]]; then

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -5,7 +5,7 @@
 
         #####  read config file if any.
 
-        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color at_color
+        unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color at_color at_color_remote
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
         unset modified_vcs_color added_vcs_color addmoded_vcs_color untracked_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
         unset rawhex_len
@@ -56,6 +56,7 @@
                 user_id_color=${user_id_color:-blue}
                 root_id_color=${root_id_color:-magenta}
                 at_color=${at_color:-green}
+                at_color_remote=${at_color_remote:-RED}
                 jobs_color_bkg=${jobs_color:-yellow}
                 jobs_color_stop=${jobs_color:-red}
                 make_color_ok=${make_color_ok:-BLACK}
@@ -371,6 +372,7 @@ set_shell_label() {
         
         if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} ]]; then
             probably_ssh_session=1
+            at_color=$at_color_remote
         else
             probably_ssh_session=
         fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -737,9 +737,7 @@ parse_git_status() {
         vcs=git
 
         ##########################################################   GIT STATUS
-	added_files=()
-	modified_files=()
-	untracked_files=()
+
         [[ $rawhex_len -gt 0 ]]  && freshness="$dim="
 
         unset branch status modified added clean init deleted untracked op detached
@@ -782,18 +780,18 @@ parse_git_status() {
         eval " $(
                 LANG=C git status --porcelain 2>/dev/null |
                         sed -n '
-                                s,^U. \([^\"][^/]*/\?\).*,         conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
-                                s,^U. \"\([^/]\+/\?\).*\"$,        conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
-                                s,^.U \([^\"][^/]*/\?\).*,         conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
-                                s,^.U \"\([^/]\+/\?\).*\"$,        conflicted=conflicted; [[ \" ${conflicted_files[@]} \" =~ \" \1 \" ]]   || conflicted_files[${#conflicted_files[@]}]=\"\1\",p
-                                s,^D. \([^\"][^/]*/\?\).*,         deleted=deleted;       [[ \" ${deleted_files[@]} \"    =~ \" \1 \" ]]   || deleted_files[${#conflicted_files[@]}]=\"\1\",p
-                                s,^D. \"\([^/]\+/\?\).*\"$,        deleted=deleted;       [[ \" ${deleted_files[@]} \"    =~ \" \1 \" ]]   || deleted_files[${#conflicted_files[@]}]=\"\1\",p
-                                s,^[MARC]. \([^\"][^/]*/\?\).*,    added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
-                                s,^[MARC]. \"\([^/]\+/\?\).*\"$,   added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
-                                s,^.[MA] \([^\"][^/]*/\?\).*,      modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
-                                s,^.[MA] \"\([^/]\+/\?\).*\"$,     modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
-                                s,^?? \([^\"][^/]*/\?\).*,         untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
-                                s,^?? \"\([^/]\+/\?\).*\"$,        untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
+                                s,^U. \([^\"][^/]*/\?\).*,         conflicted=conflicted;  conflicted_files+=(\"\1\"),p
+                                s,^U. \"\([^/]\+/\?\).*\"$,        conflicted=conflicted;  conflicted_files+=(\"\1\"),p
+                                s,^.U \([^\"][^/]*/\?\).*,         conflicted=conflicted;  conflicted_files+=(\"\1\"),p
+                                s,^.U \"\([^/]\+/\?\).*\"$,        conflicted=conflicted;  conflicted_files+=(\"\1\"),p
+                                s,^D. \([^\"][^/]*/\?\).*,         deleted=deleted;           deleted_files+=(\"\1\"),p
+                                s,^D. \"\([^/]\+/\?\).*\"$,        deleted=deleted;           deleted_files+=(\"\1\"),p
+                                s,^[MARC]. \([^\"][^/]*/\?\).*,    added=added;                 added_files+=(\"\1\"),p
+                                s,^[MARC]. \"\([^/]\+/\?\).*\"$,   added=added;                 added_files+=(\"\1\"),p
+                                s,^.[MA] \([^\"][^/]*/\?\).*,      modified=modified;        modified_files+=(\"\1\"),p
+                                s,^.[MA] \"\([^/]\+/\?\).*\"$,     modified=modified;        modified_files+=(\"\1\"),p
+                                s,^?? \([^\"][^/]*/\?\).*,         untracked=untracked;     untracked_files+=(\"\1\"),p
+                                s,^?? \"\([^/]\+/\?\).*\"$,        untracked=untracked;     untracked_files+=(\"\1\"),p
                         '   # |tee /dev/tty
         )"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -345,6 +345,11 @@ set_shell_label() {
             # FIXME: run this only if screen is in xterm (how to test for this?)
             xterm_label "$full"
 
+            # display host name in window title if remote shell
+            if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} ]]; then
+                param="@$host:$param"
+            fi
+
             printf "\033k%s\033\\" "$param"
         }
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -90,6 +90,7 @@
         count_only=${count_only:-off}
         rawhex_len=${rawhex_len:-5}
         hg_revision_display=${hg_revision_display:-none}
+        hg_multiple_heads_display=${hg_multiple_heads_display:-on}
 
 
         aj_max=20
@@ -623,6 +624,17 @@ parse_hg_status() {
         vcs_info=${branch/default/D}
         if [[ "$bookmark" ]] ;  then
                 vcs_info+=/$bookmark
+        fi
+
+        if [[ $hg_multiple_heads_display == "on" ]]; then
+            local hg_heads
+            hg_heads=$(hg heads --template '{rev}\n' $branch | wc -l)
+
+            if [[ hg_heads -gt 1 ]]; then
+                detached=detached
+                local excl_mark='!'
+                vcs_info="$detached_vcs_color$hg_heads$excl_mark$vcs_info"
+            fi
         fi
 
         local hg_vcs_char

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -34,7 +34,7 @@
         default_host_abbrev_mode=${default_host_abbrev_mode:-delete}
         default_id_abbrev_mode=${default_id_abbrev_mode:-delete}
 
-        prompt_modules_order=${prompt_modules_order:-RC VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE PROMPT}
+        prompt_modules_order=${prompt_modules_order:-RC VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE}
 
         #### check for acpi, make, disable corresponding module if not installed
         if [[ -z $(which acpi) && -z $(acpi -b) ]]; then
@@ -189,7 +189,6 @@
                 s/BATTERY/\$battery_indicator/;
                 s/CWD/\$dir_color\$cwd/;
                 s/MAKE/\$make_indicator/;
-                s/PROMPT/\$prompt_color\$prompt_char/;
                 s/ //g;
                 s/\$space\$space/\$space/g;
                 s/^\$space//;
@@ -947,7 +946,7 @@ prompt_command_function() {
         # in effect, echo collapses spaces inside the string and removes them from the start/end
         local prompt_command_string_l
         prompt_command_string_l=$(eval echo $prompt_command_string)
-        prompt_command_string_l="PS1=\"\$colors_reset$prompt_command_string_l \$colors_reset\""
+        prompt_command_string_l="PS1=\"\$colors_reset$prompt_command_string_l$prompt_color$prompt_char \$colors_reset\""
         eval $prompt_command_string_l
 
         # old static string with default order left here for reference

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -825,6 +825,9 @@ parse_hg_status() {
 
         [[ -z $modified ]] && [[ -z $untracked ]] && [[ -z $added ]] && [[ -z $deleted ]] && clean=clean
 
+        # older versions of hg log --template '{branch}' report empty if branch is default
+        [[ -z $branch ]] && branch=default
+
         vcs_info=${branch/default/D}
         if [[ "$bookmark" ]] ;  then
                 vcs_info+=/$bookmark

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -99,6 +99,13 @@
         hg_multiple_heads_display=${hg_multiple_heads_display:-on}
         command_time_threshold=${command_time_threshold:-15}
 
+        if [[ -z "$load_colors" ]]; then
+            load_colors=(BLACK red RED whiteonred)
+        fi
+        if [[ -z "$load_thresholds" ]]; then
+            load_thresholds=(100 200 300 400)
+        fi
+        load_display_style=${load_display_style:-bar}
 
 
         aj_max=20
@@ -599,12 +606,8 @@ meas_command_time() {
         unset _gp_timestamp
 }
 
-# TODO make this more configurable
 create_load_indicator () {
         local load_color load_value load_str load_bar load_mark i j
-        local -a load_colors load_thresholds
-        load_colors=(BLACK red RED whiteonred)
-        load_thresholds=(100 200 300 400)
 
         load_str=$(uptime | sed -ne 's/.* load average: \([0-9]\.[0-9]\{1,2\}\).*/\1/p')
         load_value=${load_str/\./}
@@ -625,17 +628,22 @@ create_load_indicator () {
 
         if [[ $utf8_prompt ]]; then
             load_mark="☢"
-            local load_int=$((load_value / 100 - 1))
-            local load_frac=$((load_value % 100))
-            load_frac=$((load_frac / 13))
-            local -a load_chars=( " " "▏" "▎" "▍" "▌" "▋" "▊" "▉" "█" )
+            if [[ $load_display_style == "bar" ]]; then
+                local load_int=$((load_value / 100 - 1))
+                local load_frac=$((load_value % 100))
+                load_frac=$((load_frac / 12))
+                local -a load_chars=( " " "▏" "▎" "▍" "▌" "▋" "▊" "▉" "█" )
             
-            printf -v load_str "%${load_int}s"
-            load_str=${load_str// /█} 
-            load_str+=${load_chars[$load_frac]}
+                printf -v load_str "%${load_int}s"
+                load_str=${load_str// /█} 
+                load_str+=${load_chars[$load_frac]}
+            fi
         else
             load_mark="L"
         fi
+
+        if [[ $load_display_style == "markonly" ]]; then load_str= ; fi
+
         load_indicator="$load_color$load_mark$load_str$colors_reset"
 }
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -590,7 +590,7 @@ parse_git_status() {
 
 	# info not in porcelain status
         eval " $(
-                git status 2>/dev/null |
+                LANG=C git status 2>/dev/null |
                     sed -n '
                         s/^# On branch /branch=/p
                         s/^nothing to commi.*/clean=clean/p
@@ -613,7 +613,7 @@ parse_git_status() {
                                         # A  "with space"                 <------------- WITH QOUTES
 
         eval " $(
-                git status --porcelain 2>/dev/null |
+                LANG=C git status --porcelain 2>/dev/null |
                         sed -n '
                                 s,^[MARC]. \([^\"][^/]*/\?\).*,         added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
                                 s,^[MARC]. \"\([^/]\+/\?\).*\"$,        added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -346,7 +346,7 @@ set_shell_label() {
             xterm_label "$full"
 
             # display host name in window title if remote shell
-            if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} ]]; then
+            if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} || -n ${SSH_CONNECTION} ]]; then
                 param="@$host:$param"
             fi
 
@@ -452,7 +452,7 @@ set_shell_label() {
         # if    { for ((pid=$$; $pid != 1 ; pid=`ps h -o pid --ppid $pid`)); do ps h -o command -p $pid; done | grep -q sshd && echo == REMOTE ==; }
         #then
         
-        if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} ]]; then
+        if [[ -n ${SSH_CLIENT} || -n ${SSH2_CLIENT} || -n ${SSH_CONNECTION} ]]; then
             probably_ssh_session=1
             at_color=$at_color_remote
         else

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -611,6 +611,9 @@ parse_hg_status() {
                         s/^\? \([^.].*\)/untracked=untracked; untracked_files[${#untracked_files[@]}]=\\"\1\\";/p
         '`
 
+        local branch
+        local bookmark
+
         branch=`hg branch 2> /dev/null`
 
         [[ -f $hg_root/.hg/bookmarks.current ]] && bookmark=`cat "$hg_root/.hg/bookmarks.current"`

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -103,10 +103,8 @@
         clock_style=${clock_style:-analog}
         clock_alert_interval=${clock_alert_interval:-30}
 
-        if [[ -z "$load_colors" ]]; then
+        if [[ -z "$load_colors" || -z "$load_thresholds" || ${#load_colors[@]} -ne ${#load_thresholds[@]} ]]; then
             load_colors=(BLACK red RED whiteonred)
-        fi
-        if [[ -z "$load_thresholds" ]]; then
             load_thresholds=(100 200 300 400)
         fi
         load_display_style=${load_display_style:-bar}

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -654,11 +654,11 @@ parse_hg_status() {
 
         eval `hg status 2>/dev/null |
                 sed -n '
-                        s/^M \([^.].*\)/modified=modified;    modified_files[${#modified_files[@]}]=\"\1\";/p
-                        s/^A \([^.].*\)/added=added;          added_files[${#added_files[@]}]=\"\1\";/p
-                        s/^R \([^.].*\)/deleted=deleted;      deleted_files[${#deleted_files[@]}]=\"\1\";/p
-                        s/^\! \([^.].*\)/deleted=deleted;     deleted_files[${#deleted_files[@]}]=\"\1\";/p
-                        s/^\? \([^.].*\)/untracked=untracked; untracked_files[${#untracked_files[@]}]=\\"\1\\";/p
+                        s/^M \([^.].*\)/modified=modified;     modified_files+=(\"\1\");/p
+                        s/^A \([^.].*\)/added=added;              added_files+=(\"\1\");/p
+                        s/^R \([^.].*\)/deleted=deleted;        deleted_files+=(\"\1\");/p
+                        s/^\! \([^.].*\)/deleted=deleted;       deleted_files+=(\"\1\");/p
+                        s/^\? \([^.].*\)/untracked=untracked; untracked_files+=(\"\1\");/p
         '`
 
         local branch bookmark
@@ -887,6 +887,7 @@ parse_vcs_status() {
         unset   file_list modified_files untracked_files added_files deleted_files conflicted_files
         unset   vcs vcs_info
         unset   status modified untracked added init detached deleted conflicted
+        declare -a file_list modified_files untracked_files added_files deleted_files conflicted_files
 
         [[ $vcs_ignore_dir_list =~ $PWD ]] && return
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -112,7 +112,7 @@
         ### and use the appropriate method in the runtime module
         if [[ $PARSE_VCS_STATUS =~ "svn" ]]; then
             svn_version_str=$(svn --version 2> /dev/null | head -1 | sed -ne 's/.* \([0-9]\)\.\([0-9]\{1,2\}\).*/\1\2/p')
-            if [[ svn_version_str > 16 ]]; then
+            if [[ $svn_version_str > 16 ]]; then
                 svn_use_info=1
             else
                 svn_use_info=
@@ -575,10 +575,10 @@ parse_svn_status() {
         local svn_info_str
         local myrc
 
-        if [[ -n $use_svn_info ]]; then
+        if [[ -n $svn_use_info ]]; then
             svn_info_str=$(svn info 2> /dev/null)
             myrc=$?
-           [[ $myrc -ne 0 ]] || return 1
+           [[ $myrc -eq 0 ]] || return 1
         else
            [[ -d .svn ]]     || return 1
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -506,6 +506,7 @@ create_jobs_indicator() {
 
 check_make_status() {
 
+        make_indicator=""
         [[ $make_ignore_dir_list =~ $PWD ]] && return
 
         local myrc

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -608,7 +608,7 @@ create_load_indicator () {
 
         load_str=$(uptime | sed -ne 's/.* load average: \([0-9]\.[0-9]\{1,2\}\).*/\1/p')
         load_value=${load_str/\./}
-        load_value=${load_value##0}
+        load_value=${load_value##0*}
 
         if [[ $load_value -lt ${load_thresholds[0]} ]]; then 
             load_indicator=""

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -30,6 +30,9 @@
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
 
+        default_host_abbrev_mode=${default_host_abbrev_mode:-delete}
+        default_id_abbrev_mode=${default_id_abbrev_mode:-delete}
+
         #### check for acpi, make, disable corresponding module if not installed
         if [[ -z $(which acpi) && -z $(acpi -b) ]]; then
             battery_module=off
@@ -283,7 +286,21 @@ set_shell_label() {
 
 ###################################################### ID (user name)
         id=`id -un`
-        id=${id#$default_user}
+
+        # abbreviate user name if needed
+        if   [[ "$default_id_abbrev_mode" == "delete" ]]
+        then
+            id=${id#$default_user}
+        elif [[ "$default_id_abbrev_mode" == "abbrev" ]]
+        then
+            # only abbreviate if the abbreviated string is actually shorter than the full one
+            if [[ "$id" == "$default_user" && ${#id} -ge $((${#ellipse_marker} + 1)) ]]
+            then
+                id="${id:0:1}$ellipse"
+            fi
+        #else
+            # keep full user name
+        fi
 
 ########################################################### TTY
         tty=`tty`
@@ -331,7 +348,7 @@ set_shell_label() {
 				host=`hostname -s`
 			fi
         fi
-        host=${host#$default_host}
+
         uphost=`echo ${host} | tr a-z-. A-Z_`
         if [[ $upcase_hostname = "on" ]]; then
                 host=${uphost}
@@ -343,6 +360,21 @@ set_shell_label() {
                 cksum_color_no=`echo $uphost | cksum  | awk '{print $1%6}'`
                 color_index=(green yellow blue magenta cyan white)              # FIXME:  bw,  color-256
                 host_color=${color_index[cksum_color_no]}
+        fi
+
+        # abbreviate host name if needed
+        if   [[ "$default_host_abbrev_mode" == "delete" ]]
+        then
+            host=${host#$default_host}
+        elif [[ "$default_host_abbrev_mode" == "abbrev" ]]
+        then
+            # only abbreviate if the abbreviated string is actually shorter than the full one
+            if [[ "$host" == "$default_host" && ${#host} -ge $((${#ellipse_marker} + 1)) ]]
+            then
+                host="${host:0:1}$ellipse"
+            fi
+        #else
+            # keep full host name
         fi
 
         at_color=${!at_color}
@@ -368,6 +400,7 @@ set_shell_label() {
                         user_id_color=$root_id_color
                         prompt_char="$root_prompt_char"
                 fi
+
                 color_who_where="$user_id_color$color_who_where$colors_reset"
         else
                 color_who_where=''

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -206,7 +206,7 @@
         fi
 
         ####################################################################  MARKERS
-        if [[ ("$LC_CTYPE $LC_ALL" =~ "UTF" || $LANG =~ "utf") && $TERM != "linux" ]];  then
+        if [[ ("$LC_CTYPE $LC_ALL $LANG" =~ "UTF" || $LANG =~ "utf") && $TERM != "linux" ]];  then
                 utf8_prompt=1
                 ellipse_marker="…"
         else

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -628,8 +628,8 @@ create_clock() {
             # U+1F550 (ONE OCLOCK) .. U+1F55B (TWELVE OCLOCK), for the plain hours
             # U+1F55C (ONE-THIRTY) .. U+1F567 (TWELVE-THIRTY), for the thirties
             local clockfaces=(🕧 🕐 🕜 🕑 🕝 🕒 🕞 🕓 🕟 🕔 🕠 🕕 🕡 🕖 🕢 🕗 🕣 🕘 🕤 🕙 🕥 🕚 🕦 🕛)
-            time_of_day=$((${current_time} - ${_gp_clock_timestamp_midnight}))
-            index=$(( (($time_of_day - 4500) % 43200) / 1800 ))
+            time_of_day=$(( (${current_time} - ${_gp_clock_timestamp_midnight}) % 86400 ))
+            index=$(( (($time_of_day - 900) % 43200) / 1800 ))
             clock_indicator="${!clock_color}${clockfaces[$index]}${colors_reset}"
         else
             clock_indicator="${!clock_color}\t${colors_reset}"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -466,7 +466,7 @@ set_shell_label() {
         fi
 
         # There are at least two separate problems with mc:
-        # it clobbers $PROMPT_COLOR, so none of the dynamically generated 
+        # it clobbers $PROMPT_COMMAND, so none of the dynamically generated
         # components can work,
         # and it swallows escape sequences, so colors don't work either.
         # Here we try to salvage some of the functionality for shells within mc.

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -794,7 +794,7 @@ parse_svn_status() {
         ### get status
 
         unset status modified added clean init deleted untracked conflicted op detached
-        eval `svn status 2>/dev/null |
+        eval `svn status 2>/dev/null | sed 's/\\\\/x/g' |
                 sed -n '
                     s/^A...    \([^.].*\)/        added_files+=(\"\1\");/p
                     s/^M...    \([^.].*\)/     modified_files+=(\"\1\");/p
@@ -856,7 +856,7 @@ parse_hg_status() {
         ### get status
         unset status modified added clean init deleted untracked op detached
 
-        eval `hg status 2>/dev/null |
+        eval `hg status 2>/dev/null | sed 's/\\\\/x/g' |
                 sed -n '
                         s/^M \([^.].*\)/     modified_files+=(\"\1\");/p
                         s/^A \([^.].*\)/        added_files+=(\"\1\");/p
@@ -968,7 +968,7 @@ parse_git_status() {
 
 	# info not in porcelain status
         eval " $(
-                LANG=C git status 2>/dev/null |
+                LANG=C git status 2>/dev/null | sed 's/\\\\/x/g' |
                     sed -n '
                         s/^\(# \)*On branch /branch=/p
                         s/^nothing to commi.*/clean=clean/p
@@ -991,7 +991,7 @@ parse_git_status() {
                                         # A  "with space"                 <------------- WITH QOUTES
 
         eval " $(
-                LANG=C git status --porcelain 2>/dev/null |
+                LANG=C git status --porcelain 2>/dev/null | sed 's/\\\\/x/g' |
                         sed -n '
                                 s,^U. \([^\"][^/]*/\?\).*,         conflicted_files+=(\"\1\"),p
                                 s,^U. \"\([^/]\+/\?\).*\"$,        conflicted_files+=(\"\1\"),p

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -89,6 +89,8 @@
         upcase_hostname=${upcase_hostname:-on}
         count_only=${count_only:-off}
         rawhex_len=${rawhex_len:-5}
+        hg_revision_display=${hg_revision_display:-none}
+
 
         aj_max=20
 
@@ -575,10 +577,31 @@ parse_hg_status() {
         [[ -f $hg_root/.hg/bookmarks.current ]] && bookmark=`cat "$hg_root/.hg/bookmarks.current"`
 
         [[ -z $modified ]]   &&   [[ -z $untracked ]]   &&   [[ -z $added ]]   &&   clean=clean
+
         vcs_info=${branch/default/D}
         if [[ "$bookmark" ]] ;  then
                 vcs_info+=/$bookmark
         fi
+
+        local hg_vcs_char
+        if [[ $utf8_prompt ]]; then
+            hg_vcs_char="☿"
+        else
+            hg_vcs_char=":"
+        fi
+
+        local hg_revision
+        case $hg_revision_display in
+            id)    hg_revision=$(hg id -i)
+                   hg_revision="$hex_vcs_color$hg_vcs_char${hg_revision:0:$rawhex_len}"
+                   ;;
+            num)   hg_revision=$(hg id -n)
+                   hg_revision="$hex_vcs_color$hg_vcs_char$hg_revision"
+                   ;;
+            *)     hg_revision="" ;;
+        esac
+
+        vcs_info+=$hg_revision
  }
 
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -72,9 +72,9 @@
         fi
         unset cols
 
-	#### prompt character, for root/non-root
-	prompt_char=${prompt_char:-'>'}
-	root_prompt_char=${root_prompt_char:-'>'}
+        #### prompt character, for root/non-root
+        prompt_char=${prompt_char:-'>'}
+        root_prompt_char=${root_prompt_char:-'>'}
 
         #### vcs colors
                  init_vcs_color=${init_vcs_color:-WHITE}        # initial
@@ -83,7 +83,7 @@
                 added_vcs_color=${added_vcs_color:-green}       # Changes to be committed:
             untracked_vcs_color=${untracked_vcs_color:-BLUE}    # Untracked files:
               deleted_vcs_color=${deleted_vcs_color:-yellow}    # Deleted files:
-           conflicted_vcs_color=${conflicted_vcs_color:-CYAN}    # Conflicted files:
+           conflicted_vcs_color=${conflicted_vcs_color:-CYAN}   # Conflicted files:
                    op_vcs_color=${op_vcs_color:-MAGENTA}
              detached_vcs_color=${detached_vcs_color:-RED}
 
@@ -186,7 +186,7 @@
                CYAN='\['`tput setaf 6; tput bold`'\]'
               WHITE='\['`tput setaf 7; tput bold`'\]'
 
-              whiteonred='\['`tput setaf 7; tput setab 1; tput bold`'\]'
+         whiteonred='\['`tput setaf 7; tput setab 1; tput bold`'\]'
 
                 dim='\['`tput sgr0; tput setaf p1`'\]'  # half-bright
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -639,7 +639,7 @@ parse_svn_status() {
         [[ -z $conflicted ]] && \
         clean=clean
 
-        vcs_info=r$hex_vcs_color$rev
+        vcs_info=r$hex_vcs_color$rev$colors_reset
  }
 
 parse_hg_status() {

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -662,7 +662,8 @@ parse_hg_status() {
         local hg_vcs_char hg_up_char
         if [[ $utf8_prompt ]]; then
             hg_vcs_char="☿"
-            hg_up_char="▲"
+            hg_up_char="⬆"
+
         else
             hg_vcs_char=":"
             hg_up_char="^"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -655,7 +655,13 @@ create_clock() {
 create_load_indicator () {
         local load_color load_value load_str load_bar load_mark i j
 
-        load_str=$(uptime | sed -ne 's/.* load average: \([0-9]\.[0-9]\{1,2\}\).*/\1/p')
+        if [[ "$OSTYPE" =~ "linux" ]]; then
+            local eol
+            read load_str eol < /proc/loadavg
+            load_str=${load_str## *}
+        else
+            load_str=$(uptime | sed -ne 's/.* load average: \([0-9]\.[0-9]\{1,2\}\).*/\1/p')
+        fi
         load_value=${load_str/\./}
         load_value=$((10#$load_value))
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -37,13 +37,12 @@
         prompt_modules_order=${prompt_modules_order:-RC VIRTUALENV VCS WHO_WHERE JOBS BATTERY CWD MAKE}
 
         #### check for acpi, make, disable corresponding module if not installed
-        if [[ -z $(which acpi) || -z $(acpi -b) ]]; then
+        if [[ -z $(which acpi 2> /dev/null) || -z $(acpi -b) ]]; then
             battery_module=off
         fi
-        if [[ -z $(which make) ]]; then
+        if [[ -z $(which make 2> /dev/null) ]]; then
             make_module=off
         fi
-
 
         #### dir, rc, root color
         cols=`tput colors`                              # in emacs shell-mode tput colors returns -1

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -666,7 +666,7 @@ create_load_indicator () {
                 local -a load_chars=( " " "▏" "▎" "▍" "▌" "▋" "▊" "▉" "█" )
             
                 printf -v load_str "%${load_int}s"
-                load_str=${load_str// /█} 
+                load_str=${load_str// /◙}
                 load_str+=${load_chars[$load_frac]}
             fi
         else

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -196,14 +196,6 @@
                 s/\$space/ /g;
                 ')
 
-        #######  work around for MC bug.
-        #######  specifically exclude emacs, want full when running inside emacs
-        if   [[ -z "$TERM"   ||  ("$TERM" = "dumb" && -z "$INSIDE_EMACS")  ||  -n "$MC_SID" ]];   then
-                unset PROMPT_COMMAND
-                PS1="\w$prompt_char "
-                return 0
-        fi
-
         ####################################################################  MARKERS
         ellipse_marker_utf8="…"
         ellipse_marker_plain="..."
@@ -447,6 +439,24 @@ set_shell_label() {
         else
                 color_who_where=''
         fi
+
+        # There are at least two separate problems with mc:
+        # it clobbers $PROMPT_COLOR, so none of the dynamically generated 
+        # components can work,
+        # and it swallows escape sequences, so colors don't work either.
+        # Here we try to salvage some of the functionality for shells within mc.
+        #
+        # specifically exclude emacs, want full when running inside emacs
+        if [[ -z "$TERM" || ("$TERM" = "dumb" && -z "$INSIDE_EMACS") || -n "$MC_SID" ]]; then
+            unset PROMPT_COMMAND
+            if [[ -n $id  || -n $host ]] ;   then
+                PS1="$color_who_where:\w$prompt_char "
+            else
+                PS1="\w$prompt_char "
+            fi
+            return 0
+        fi
+
 
 create_battery_indicator () {
         # if not a laptop: :

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -477,6 +477,8 @@ create_jobs_indicator() {
 
 check_make_status() {
 
+        [[ $make_ignore_dir_list =~ $PWD ]] && return
+
         if [[ -e Makefile ]]; then
             if [[ $utf8_prompt ]]; then
                 make_indicator="⚑"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -44,6 +44,7 @@
         if [[ -n "$cols" && $cols -ge 8 ]];  then       #  if terminal supports colors
                 dir_color=${dir_color:-CYAN}
                 slash_color=${slash_color:-CYAN}
+                prompt_color=${prompt_color:-white}
                 rc_color=${rc_color:-red}
                 virtualenv_color=${virtualenv_color:-green}
                 user_id_color=${user_id_color:-blue}
@@ -307,6 +308,7 @@ set_shell_label() {
 
         dir_color=${!dir_color}
         slash_color=${!slash_color}
+        prompt_color=${!prompt_color}
         rc_color=${!rc_color}
         virtualenv_color=${!virtualenv_color}
         user_id_color=${!user_id_color}
@@ -849,7 +851,7 @@ prompt_command_function() {
 
         cwd=${cwd//\//$slash_color\/$dir_color}
 
-        PS1="$colors_reset$rc$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$tail_local$make_indicator$dir_color$prompt_char $colors_reset"
+        PS1="$colors_reset$rc$head_local$color_who_where$colors_reset$jobs_indicator$battery_indicator$dir_color$cwd$tail_local$make_indicator$prompt_color$prompt_char $colors_reset"
 
         unset head_local tail_local pwd
  }

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -388,20 +388,20 @@ set_shell_label() {
         tty=`echo $tty | sed "s:/dev/pts/:p:; s:/dev/tty::" `           # RH tty devs
         tty=`echo $tty | sed "s:/dev/vc/:vc:" `                         # gentoo tty devs
 
+        # replace tty name with screen number
+        # however, "screen" as $TERM may also mean tmux
         if [[ "$TERM" =~ "screen" ]] ;  then
-
-                #       [ "$WINDOW" = "" ] && WINDOW="?"
-                #
-                #               # if under screen then make tty name look like s1-p2
-                #               # tty="${WINDOW:+s}$WINDOW${WINDOW:+-}$tty"
-                #       tty="${WINDOW:+s}$WINDOW"  # replace tty name with screen number
-                tty="$WINDOW"  # replace tty name with screen number
+            if [[ "$STY" ]]; then
+                tty="$WINDOW"
+            elif [[ "$TMUX" ]]; then
+                tty=$(tmux display-message -p "#I")
+            fi
         fi
 
         # we don't need tty name under X11
         case $TERM in
-                xterm* | rxvt* | gnome-terminal | konsole | eterm* | wterm | cygwin)  unset tty ;;
-                *);;
+            xterm* | rxvt* | gnome-terminal | konsole | eterm* | wterm | cygwin)  unset tty ;;
+            *);;
         esac
 
         dir_color=${!dir_color}

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -401,11 +401,13 @@ set_shell_label() {
                 tty=$(tmux display-message -p "#I")
                 # also save tmux session name so that we can include it in the window title
                 _gp_tmux_session=$(tmux display-message -p "#S")
+            else
+                tty=
             fi
 
             # if we start an ssh connection from within a screen/tmux session,
             # the "screen" $TERM setting tends to be preserved.
-            # In this case we don't want a tty (it would be a misleading "0"),
+            # In this case we don't want the tty displayed (it would be a misleading "0"),
             # unless there is an actual screen/tmux session on the server too.
             if [[ -n "$tty" ]]; then
                 # replace tty number with circled numbers

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -152,9 +152,9 @@
 
         ####################################################################  MARKERS
         if [[ "$LC_CTYPE $LC_ALL" =~ "UTF" && $TERM != "linux" ]];  then
-                elipses_marker="…"
+                ellipse_marker="…"
         else
-                elipses_marker="..."
+                ellipse_marker="..."
         fi
 
         export who_where
@@ -200,7 +200,7 @@ cwd_truncate() {
 
 
 		# trunc middle if over limit
-                if   [[ ${#path_middle}   -gt   $(( $cwd_middle_max + ${#elipses_marker} + 5 )) ]];   then
+                if   [[ ${#path_middle}   -gt   $(( $cwd_middle_max + ${#ellipse_marker} + 5 )) ]];   then
 
 			# truncate
 			middle_tail=${path_middle:${#path_middle}-${cwd_middle_max}}
@@ -212,7 +212,7 @@ cwd_truncate() {
 
 			# use truncated only if we cut at least 4 chars
 			if [[ $((  ${#path_middle} - ${#middle_tail}))  -gt 4  ]];  then
-				cwd=$path_head$elipses_marker$middle_tail$path_last_dir
+				cwd=$path_head$ellipse_marker$middle_tail$path_last_dir
 			fi
                 fi
         fi
@@ -619,7 +619,7 @@ parse_vcs_status() {
         if [[ ${#file_list} -gt $max_file_list_length ]]  ;  then
                 file_list=${file_list:0:$max_file_list_length}
                 if [[ $max_file_list_length -gt 0 ]]  ;  then
-                        file_list="${file_list% *} $elipses_marker"
+                        file_list="${file_list% *} $ellipse_marker"
                 fi
         fi
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -613,7 +613,7 @@ create_load_indicator () {
         load_value=${load_str/\./}
         load_value=$((10#$load_value))
 
-        if [[ $load_value -lt ${load_thresholds[0]} ]]; then 
+        if [[ $load_value -le ${load_thresholds[0]} ]]; then
             load_indicator=""
             return
         fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -8,7 +8,7 @@
         unset make_color_ok make_color_dirty jobs_color_bkg jobs_color_stop slash_color slash_color_readonly at_color at_color_remote
         unset command_time_color clock_color
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
-        unset modified_vcs_color added_vcs_color untracked_vcs_color deleted_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
+        unset modified_vcs_color added_vcs_color untracked_vcs_color deleted_vcs_color op_vcs_color detached_vcs_color hex_vcs_color conflicted_vcs_color
         unset rawhex_len
 
         conf=git-prompt.conf;                   [[ -r $conf ]]  && . $conf

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -924,9 +924,9 @@ parse_hg_status() {
             hg_vcs_char="☿"
             hg_up_char="⬆"
             case $phase in
-                public)  phase="${green}⚌";; # ☻
-                draft)   phase="${yellow}⚍";; # ☺
-                secret)  phase="${red}⚏";; # ☹
+                public)  phase="${green}☻";; # ☻ # ⚌
+                draft)   phase="${yellow}☺";; # ☺ # ⚍
+                secret)  phase="${red}☹";; # ☹ # ⚏
                 *)       phase="" ;;
             esac
         else

--- a/index.txt
+++ b/index.txt
@@ -13,8 +13,8 @@
 
 image:screenshot-prompt-basic.png[basic usage]
 
-Digit [red]*1* on 3rd line is `false(1)` exit code. Also on non-zero exit code
-terminal bell is sounded.  Bell is turned off by default (to set softer
+Digit [red]*1* on the 3rd line is a `false(1)` exit code. Also on a non-zero exit code
+the terminal bell is sounded.  The bell is turned off by default (to set softer
 terminal bell use `setterm`).
 
 
@@ -40,8 +40,8 @@ image:screenshot-prompt-git.png[git module screenshot]
 ==  Subversion/SVN 
 image:screenshot-svn.png[svn module screenshot]
 
-SVN module disabled by default because even on moderate sized working
-directories there is noticeable delay for prompt display.  SVN is slower than
+SVN module is disabled by default because even on moderate sized working
+directories there is a noticeable delay for prompt display.  SVN is slower than
 GIT.  Enable if needed in <<config,config>> 
 
 ==  Mercurial/HG
@@ -57,16 +57,16 @@ HG module was developed by Lee Nussbaum `<wln AT scrunch.org>`.
 == Labels
 
 Labels are visual cues to help figure out what terminal is running what command.
-It is generalization of xterm-title but differ from xterm-title that it
+It is a generalization of xterm-title but it differ from xterm-title in that it
 can be displayed in other places (on Screen(1) windows titles for example).
-Also label can display currently executed command (when bash prompt obviously
-is not displayed). Because labels have less space then prompt, instead of full path
-only last dir is shown.
-On screenshot below labels are in red ovals.
+Additionally, the label can display currently executed command (when bash prompt obviously
+is not displayed). Because such labels have less space than the prompt, instead of the full path
+only the bottommost directory is shown.
+On screenshot below the labels are highlighted with red ovals.
 
 image:screenshot-labels.png["labels screenshot", width="300", link="screenshot-labels.png"]
 
-The `screen(1)` status line at bottom of smaller gnome-terminal is displayed with
+The `screen(1)` status line at the bottom of the smaller gnome-terminal is displayed with
 following line in `~/.screenrc`:
 
 ---------
@@ -76,11 +76,11 @@ caption always "%{= kw}%-w%{= bw}%n %t%{-}%+w %-= @%H - %LD %d %LM - %c"
 
 == Simple AutoJump
 
-AutoJump is python script from Joel Schaerer providing shortcuts for jumping
-to directories you once visited.  Git-prompt have built-in, simplified
+AutoJump is a python script from Joel Schaerer providing shortcuts for jumping
+to directories you once visited.  Git-prompt has a built-in, simplified version of
 autojump. It is only about 10 lines of bash code (vs original 100+ python
-LOC), there is no database. It remembers only directories from current
-session. It selects not most frequent dir, but last visited. Matches are done
+LOC), there is no database. It remembers only directories from the current
+session. It selects not the most frequent dir, but the last visited. Matches are done
 from beginning of of dir name (not path name).
 
 -----------------
@@ -103,7 +103,7 @@ Download  link:git-prompt.sh[] or get it with GIT:
   git clone git://github.com/lvv/git-prompt.git
 ---------------
 
-Put following command at the end of your profile (`~/.bash_profile` or `~/.profile`) 
+Put the following command at the end of your profile (`~/.bash_profile` or `~/.profile`) 
 
 --------------------
   [[ $- == *i* ]]   &&   . /path/to/git-prompt.sh
@@ -129,15 +129,15 @@ git config [--global] --unset i18n.logoutputencoding
 == GIT-PROMPT config 
 [[config]]
 
-Is optional.  If config file is not found then git-prompt uses defaults. 
+Optional.  If no config file is found then git-prompt uses defaults. 
 Defaults are listed in example `git-prompt.conf`.  Git-prompt looks (in listed order)
-for config file in following locations:
+for the config file in the following locations:
 
 * `/etc/git-prompt.conf`
 * `~/.git-prompt.conf`
 
 Copy example config `git-prompt.conf` 
-to any of above locations and customize as needed.
+to any of the above locations and customize as needed.
 
 
 == Limitations
@@ -145,6 +145,9 @@ to any of above locations and customize as needed.
 * cd-ing into something like linux kernel git working directory for the 1st
   time (with cold cache) might take up to 10 seconds (that is how long `git status` executes).
   Use `vcs_ignore_dir_list` in config if you want to ingnore such dirs.
+* Similarly, the make module may induce a noticeable delay in directories with a large and 
+  complex Makefile (because it has to run `make -q' to figure out its build status).
+  Use `make_ignore_dir_list` in config to ingnore such dirs.
 * Because you will be always reminded about dirty repo (not checked-in files),
   you will maintain `.gitignore` and commit more often.
 * This prompt is most useful if your screen have enough width.
@@ -171,11 +174,14 @@ dependencies are standard unix utils.
 * locale  (glibc)
 * id   (core utils)
 * cksum (core utils)
+* awk
 
 * git  (optional)
 * svn  (optional)
 * hg   (optional)
 
+* make (optional)
+* acpi (optional, for battery module)
 
 == Todo
 
@@ -206,7 +212,7 @@ time consuming ops in postconfig which is executed only once.
 - Dan Bravender <dan.bravender AT gmail.com>
 - Thomas Geffert <thomas.geffert AT arcutronix.com>
 - Tibor Simko <tibor.simko AT cern.ch>
-
+- Peter Juhasz httpx://github.com/pjuhasz[]
 
 [bibliography]
 .References

--- a/index.txt
+++ b/index.txt
@@ -47,6 +47,12 @@ GIT.  Enable if needed in <<config,config>>
 ==  Mercurial/HG
 HG module was developed by Lee Nussbaum `<wln AT scrunch.org>`.
 
+== Additional features
+
+* Battery status (for laptops)
+* Background jobs indicator
+* Makefile status check
+* Order of prompt elements can be changed 
 
 == Labels
 


### PR DESCRIPTION
Hello,

I've been using your git-prompt for a while, adding new modules and features from time to time.
A few days ago I found your github, so I decided to fork and add my changes so that they can be merged back to the main repo.

Rationale for the new features:
- when I'm on a laptop, I want to know how much battery life still remains - this information is displayed by Unicode bar-chart drawing characters to save space.
- I usually have several tabs open in gnome-terminal, and some of the shells run programs in the background (like editors or number-crunching scripts). I like to be reminded not to close these tabs because I'd lose the background processes with them.
- If a project has a makefile (as most software projects do), I like to be able to tell with a glance whether the executables are up-to-date or I have to remake them.

Apart from these, I made the order of modules configurable and fixed a few minor things.
