### PR TITLE
add ability to ignore AFS directories

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -568,9 +568,7 @@ parse_vcs_status() {
         [[ $vcs_ignore_dir_list =~ $PWD ]] && return
 
         # make sure we're not in an AFS directory
-        if [ -n "$vcs_ignore_afs" ] && which fs >/dev/null 2>&1; then
-                fs examine >/dev/null 2>&1 || return
-        fi
+        [[ $vcs_ignore_afs = "on" ]] && (which fs && fs examine) >/dev/null 2>&1 && return
 
         eval   $PARSE_VCS_STATUS
 


### PR DESCRIPTION
AFS (at least for me) slows prompt (re-)display to a crawl, so I added a configuration option to avoid running the prompt script when in an AFS directory.
