### PR TITLE
add ability to ignore AFS directories

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -46,6 +46,9 @@
 #  they are always dirty  (ex: home, /etc) or directory with huge repo (ex: linux src)
 ## vcs_ignore_dir_list=" /etc $HOME /usr/src/linux.git "
 
+#  Do not do VCS parsing for AFS directories
+## vcs_ignore_afs=on
+
 ###########################################################   COLOR 
 
 ###  directory, exit code, root color 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -567,6 +567,9 @@ parse_vcs_status() {
 
         [[ $vcs_ignore_dir_list =~ $PWD ]] && return
 
+        # make sure we're not in an AFS directory
+        [[ $vcs_ignore_afs = "on" ]] && (which fs && fs examine) >/dev/null 2>&1 && return
+
         eval   $PARSE_VCS_STATUS
 
 


### PR DESCRIPTION
Add configuration option to avoid running the prompt script when in an AFS directory, as AFS (at least for me) slows prompt (re-)display to a crawl.
