### PR TITLE
Remove back references in freshness detection code

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -444,9 +444,9 @@ parse_git_status() {
                         s/^\(# \)*On branch /branch=/p
                         s/^nothing to commi.*/clean=clean/p
                         s/^\(# \)*Initial commi.*/init=init/p
-                        s/^\(# \)*Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}↑/p
-                        s/^\(# \)*Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}↓/p
-                        s/^\(# \)*Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}↕/p
+                        s/^\(# \)*Your branch is ahead of ..\+. by [[:digit:]]\+ commit.*/freshness=${WHITE}↑/p
+                        s/^\(# \)*Your branch is behind ..\+. by [[:digit:]]\+ commit.*/freshness=${YELLOW}↓/p
+                        s/^\(# \)*Your branch and ..\+. have diverged.*/freshness=${YELLOW}↕/p
                     '
         )"
 


### PR DESCRIPTION
Commit eeff805e0bcdab5317ed1027bef2b625a8f7f94b (fix for issue #37) breaks detection of branch freshness. To avoid further confusion around this code, I have simplified it to not use regex back references.
