### PR TITLE
Fix $HOME -> ~ substitution regression in fd0b88da.

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -177,7 +177,7 @@ cwd_truncate() {
         # arg1: max path lenght
         # returns abbrivated $PWD  in public "cwd" var
 
-        cwd="${PWD/$HOME/~}"             # substitute  "~"
+        cwd="${PWD/$HOME/\~}"             # substitute  "~"
 
         case $1 in
                 full)


### PR DESCRIPTION
\~ is needed in bash 4.3.