### PR TITLE
Add new "relative" option to cwd_truncate

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -188,6 +188,19 @@ cwd_truncate() {
                         [[ "$PWD" == "$HOME" ]]  &&  cwd="~"
                         return
                         ;;
+                relative)
+                        local git_dir=$(git rev-parse --git-dir 2>/dev/null)
+                        local absolute_path=$(readlink -e $git_dir 2>/dev/null)
+                        local parent_path=${absolute_path%%/.git}
+                        local repo_name=${parent_path##/*/}
+                        if [[ "$repo_name" == "" ]]
+                        then
+                            # default to "full"
+                            return
+                        fi
+                        cwd="$repo_name${PWD##$parent_path}"
+                        return
+                        ;;
                 *)
                         ;;
         esac
@@ -700,7 +713,6 @@ prompt_command_function() {
         fi
 
         cwd=${PWD/$HOME/\~}                     # substitute  "~"
-        set_shell_label "${cwd##[/~]*/}/"       # default label - path last dir
 
 	parse_virtualenv_status
         parse_vcs_status
@@ -713,6 +725,7 @@ prompt_command_function() {
         # if cwd_cmd have back-slash, then assign it value to cwd
         # else eval cwd_cmd,  cwd should have path after exection
         eval "${cwd_cmd/\\/cwd=\\\\}"
+        set_shell_label "${cwd}"
 
         PS1="$colors_reset$rc$head_local$color_who_where$dir_color$cwd$tail_local$dir_color$prompt_char $colors_reset"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -189,16 +189,15 @@ cwd_truncate() {
                         return
                         ;;
                 relative)
-                        local git_dir=$(git rev-parse --git-dir 2>/dev/null)
-                        local absolute_path=$(readlink -e $git_dir 2>/dev/null)
-                        local parent_path=${absolute_path%%/.git}
-                        local repo_name=${parent_path##/*/}
-                        if [[ "$repo_name" == "" ]]
-                        then
-                            # default to "full"
-                            return
+                        if [[ $git_module = "on" && -d ${git_dir} ]]; then
+                                local absolute_path=$(readlink -e $git_dir 2>/dev/null)
+                                local parent_path=${absolute_path%%/.git}
+                                local repo_name=${parent_path##/*/}
+                                if [[ -n "$repo_name" ]]
+                                then
+                                        cwd="$repo_name${PWD##$parent_path}"
+                                fi
                         fi
-                        cwd="$repo_name${PWD##$parent_path}"
                         return
                         ;;
                 *)


### PR DESCRIPTION
## Overview
This keeps the window title shorter: once I'm in a Git repo, I only care about the repo folder's name.  It also makes sure the "shell label" uses the same value of the computed `cwd`.

# Manual testing

This is how I use it in my `~/.git-prompt.conf` file:
```
cwd_cmd='cwd_truncate relative'
```

...and it looks like this:

![image](https://user-images.githubusercontent.com/297515/120019952-13615b80-bfb7-11eb-86bd-c4cfdf72ed99.png)

Mission accomplished!