### PR TITLE
feat: add show_who_where option

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -12,6 +12,7 @@
 # max_file_list_length=100      # in characters
 # count_only=off                # off - display file list; on - display file count
 # rawhex_len=5                  # length of git rawhex revision id display (use 0 to hide it)
+# show_who_where=on             # on (default) show user@host; off don't show it
 
 ############################################################   MODULES
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -11,6 +11,7 @@
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
         unset modified_vcs_color added_vcs_color addmoded_vcs_color untracked_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
         unset rawhex_len
+        unset show_who_where
 
         # work around for conflict with vte.sh
         unset VTE_VERSION
@@ -74,6 +75,7 @@
         upcase_hostname=${upcase_hostname:-on}
         count_only=${count_only:-off}
         rawhex_len=${rawhex_len:-5}
+        show_who_where=${show_who_where:-on}
 
         aj_max=20
 
@@ -332,7 +334,7 @@ set_shell_label() {
 #################################################################### WHO_WHERE
         #  [[user@]host[-tty]]
 
-        if [[ -n $id  || -n $host ]] ;   then
+        if [[ "$show_who_where" == "on" && ( -n $id  || -n $host ) ]] ;   then
                 [[ -n $id  &&  -n $host ]]  &&  at='@'  || at=''
                 color_who_where="${id}${host:+$host_color$at$host}${tty:+ $tty}"
                 plain_who_where="${id}$at$host"


### PR DESCRIPTION
## Overview

I use a few computers where I'm the only user and I know what host I'm on, so there's no need to show that information on every prompt.

# Manual testing
In my `~/.git-prompt.conf` file, I set:
```
show_who_where=off
```

...and this is what it looks like:

![image](https://user-images.githubusercontent.com/297515/120022875-021a4e00-bfbb-11eb-962a-3d5769e0b0ae.png)

Mission accomplished!